### PR TITLE
[tests] Use correct DSME D-Bus object path. Fixes JB#52779

### DIFF
--- a/tests/tests.xml
+++ b/tests/tests.xml
@@ -7,7 +7,7 @@
               <step expected_result="0">/usr/sbin/dsmetool -v</step>
             </case>
             <case name="dsme-dbus-interface" type="Functional" level="Component">
-              <step expected_result="0">dbus-send --system --print-reply --dest=com.nokia.dsme /com/nokia/dsme com.nokia.dsme.request.get_version</step>
+              <step expected_result="0">dbus-send --system --print-reply --dest=com.nokia.dsme /com/nokia/dsme/request com.nokia.dsme.request.get_version</step>
             </case>
         </set> 
     </suite>


### PR DESCRIPTION
As DSME nowadays actually cares about object paths, also test code
needs to use the correct one.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>