### PR TITLE
[dmse] Allow root/privileged users to be privileged when wheel is enabled.

### DIFF
--- a/dsme/utility.c
+++ b/dsme/utility.c
@@ -84,7 +84,7 @@ dsme_user_is_privileged(uid_t uid, gid_t gid)
             }
         }
     }
-#else
+#endif
     /* Check if UID/GID is root/privileged */
     if( uid != 0 && gid != 0 ) {
         struct passwd *pw = getpwnam("privileged");
@@ -99,7 +99,6 @@ dsme_user_is_privileged(uid_t uid, gid_t gid)
     is_privileged = true;
 
 EXIT:
-#endif
     return is_privileged;
 }
 


### PR DESCRIPTION
It was possible for root users to be not privileged while 'regular' non-root users in the 'wheel' group are privileged.
This changes the logic such that wheel users and root/privileged users are privileged.

This changes the logic introduced in https://github.com/sailfishos/dsme/pull/2.