### PR TITLE
[iphb] Keep rtc device opened only when needed. Fixes JB#62412

### DIFF
--- a/rpm/dsme.spec
+++ b/rpm/dsme.spec
@@ -59,11 +59,11 @@ test -e Makefile || (%configure --disable-static \
     --disable-validatorlistener \
     --enable-abootsettings)
 
-%make_build
+%make_build _LIBDIR=%{_libdir}
 
 %install
 rm -rf %{buildroot}
-%make_install
+%make_install _LIBDIR=%{_libdir}
 
 install -d %{buildroot}%{_sysconfdir}/dsme/
 install -D -m 644 reboot-via-dsme.sh %{buildroot}/etc/profile.d/reboot-via-dsme.sh


### PR DESCRIPTION
Some android services insist on inspecting rtc time on startup. Having
DSME hold on to rtc device permanently causes such services to be blocked.

Modify DSME logic so that rtc device is opened only when there is actual
need for it and closed once the need is gone.
