### PR TITLE
avoid undefined behaviour

### DIFF
--- a/modules/iphb.c
+++ b/modules/iphb.c
@@ -276,10 +276,9 @@ static bool monotime_get_tv(struct timeval *tv)
     struct timespec ts;
 
 #if defined(CLOCK_BOOTTIME)
-    if( clock_gettime(CLOCK_BOOTTIME, &ts) < 0 ) {
-        if( clock_gettime(CLOCK_MONOTONIC, &ts) < 0 )
-            timerclear(tv);
-    }
+    if( clock_gettime(CLOCK_BOOTTIME, &ts) < 0 &&
+        clock_gettime(CLOCK_MONOTONIC, &ts) < 0 )
+        timerclear(tv);
 #else
     if( clock_gettime(CLOCK_MONOTONIC, &ts) < 0 )
 	timerclear(tv);


### PR DESCRIPTION
I was trying to compile DSME with the new GCC, but it reported undefined behavior:

```
iphb.c: In function 'xtimed_config_status_cb':
iphb.c:2688:5: error: 'now.tv_sec' may be used uninitialized [-Werror=maybe-uninitialized]
 2688 |     clientlist_rethink_rtc_wakeup(&now);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
iphb.c:2686:20: note: 'now.tv_sec' was declared here
 2686 |     struct timeval now;
      |                    ^~~
iphb.c:2688:5: error: 'now.tv_usec' may be used uninitialized [-Werror=maybe-uninitialized]
 2688 |     clientlist_rethink_rtc_wakeup(&now);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
iphb.c:2686:20: note: 'now.tv_usec' was declared here
 2686 |     struct timeval now;
      |                    ^~~
```

```
iphb.c: In function 'xtimed_alarm_status_cb':
iphb.c:2666:9: error: 'now.tv_sec' may be used uninitialized [-Werror=maybe-uninitialized]
 2666 |         clientlist_rethink_rtc_wakeup(&now);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
iphb.c:2664:24: note: 'now.tv_sec' was declared here
 2664 |         struct timeval now;
      |                        ^~~
iphb.c:2666:9: error: 'now.tv_usec' may be used uninitialized [-Werror=maybe-uninitialized]
 2666 |         clientlist_rethink_rtc_wakeup(&now);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
iphb.c:2664:24: note: 'now.tv_usec' was declared here
 2664 |         struct timeval now;
      |                        ^~~
In function 'client_handle_stat_req',
    inlined from 'epollfd_handle_client_req' at iphb.c:2934:13,
    inlined from 'epollfd_iowatch_cb' at iphb.c:3024:13:
iphb.c:2147:33: error: 'tv_now.tv_sec' may be used uninitialized [-Werror=maybe-uninitialized]
 2147 |         stats.next_hb = next_hb - tv_now.tv_sec;
      |                         ~~~~~~~~^~~~~~~~~~~~~~~
iphb.c: In function 'epollfd_iowatch_cb':
iphb.c:2130:23: note: 'tv_now.tv_sec' was declared here
 2130 |     struct timeval    tv_now;
      |                       ^~~~~~
```

I have traced the problem to the `monotime_get_tv` function. However, I am unsure about the fix. I created this merge request primarily because the project doesn't have an enabled issue tracker.