### PR TITLE
[dsme] Add enablers for blocking shutdown via D-Bus. JB#62532

### DIFF
--- a/dsme/dsme-rd-mode.c
+++ b/dsme/dsme-rd-mode.c
@@ -33,6 +33,7 @@ bool dsme_rd_mode_enabled(void)
     return dsme_rd_mode_get_flags() != 0;
 }
 
-const char* dsme_rd_mode_get_flags(void) {
+const char* dsme_rd_mode_get_flags(void)
+{
     return getenv(DSME_RD_FLAGS_ENV);
 }

--- a/dsme/dsme-server.c
+++ b/dsme/dsme-server.c
@@ -100,7 +100,6 @@ static void usage(const char *progname)
     printf(fmt, progname);
 }
 
-
 /**
  * Signal_Handler
  *
@@ -129,7 +128,6 @@ bool dsme_in_valgrind_mode(void)
 {
     return valgrind_mode_enabled;
 }
-
 
 static int parse_verbosity(const char *arg)
 {
@@ -379,7 +377,7 @@ int main(int argc, char *argv[])
       goto EXIT;
   }
 #ifdef DSME_SYSTEMD_ENABLE
-  /* Inform main process that we are ready 
+  /* Inform main process that we are ready
    * Main process will inform systemd
    */
   if (signal_systemd) {

--- a/dsme/dsme-wdd-wd.c
+++ b/dsme/dsme-wdd-wd.c
@@ -43,9 +43,7 @@
 
 #include <linux/watchdog.h>
 
-
 #define DSME_STATIC_STRLEN(s) (sizeof(s) - 1)
-
 
 typedef struct wd_t {
     const char* file;   /* pathname of the watchdog device */

--- a/dsme/dsme-wdd.c
+++ b/dsme/dsme-wdd.c
@@ -66,14 +66,12 @@
 
 #define DSME_MAXPING 5
 
-
 static void signal_handler(int  signum);
 static void usage(const char *  progname);
 static int  daemonize(void);
 static void mainloop(unsigned sleep_interval,
                      int      pipe_to_child,
                      int      pipe_from_child);
-
 
 static volatile bool run = true;
 
@@ -157,7 +155,6 @@ static int daemonize(void)
             break;
     }
 
-
     /* Detach tty */
     setsid();
 
@@ -201,12 +198,10 @@ static int daemonize(void)
     }
     close(i);
 
-
     /* signals */
     signal(SIGTSTP, SIG_IGN);   /* ignore tty signals */
     signal(SIGTTOU, SIG_IGN);
     signal(SIGTTIN, SIG_IGN);
-
 
     return 0;
 }
@@ -272,7 +267,6 @@ static void parse_options(int   argc,   /* in  */
     }
 }
 
-
 static bool set_nonblocking(int fd)
 {
     bool set = false;
@@ -289,7 +283,6 @@ static bool set_nonblocking(int fd)
 
     return set;
 }
-
 
 static void ping(int pipe)
 {
@@ -334,7 +327,6 @@ static bool pong(int pipe)
 
     return got_pong;
 }
-
 
 static void mainloop(unsigned sleep_interval,
                      int      pipe_to_child,
@@ -463,7 +455,6 @@ static bool kill_and_wait(pid_t pid, int sig, int max_wait)
   }
 
 EXIT:
-
   /* Cancel alarm and reset signal handler back to defaults */
   alarm(0);
   signal(SIGALRM, SIG_DFL);
@@ -599,7 +590,6 @@ int main(int argc, char *argv[])
     signal(SIGUSR1, signal_handler);
 #endif
 
-
     // protect from oom
     if (!protect_from_oom()) {
         fprintf(stderr, ME "Couldn't protect from oom: %s\n", strerror(errno));
@@ -686,7 +676,6 @@ int main(int argc, char *argv[])
                 DSME_SERVER_PATH,
                 strerror(errno));
         _exit(EXIT_FAILURE);
-
     } else {
         // parent
 

--- a/dsme/dsmesock.c
+++ b/dsme/dsmesock.c
@@ -210,7 +210,6 @@ accept_client(GIOChannel *src, GIOCondition cnd, gpointer aptr)
     add_client(conn), conn = 0;
 
 cleanup:
-
     if( chn )
         g_io_channel_unref(chn);
 

--- a/dsme/logging.c
+++ b/dsme/logging.c
@@ -167,7 +167,6 @@ bool               dsme_log_open              (log_method method, int verbosity,
 void               dsme_log_close             (void);
 void               dsme_log_stop              (void);
 
-
 /* ========================================================================= *
  * Dynamic Configuration
  * ========================================================================= */
@@ -673,6 +672,7 @@ dsme_log_thread(void* param)
                 goto EXIT;
         }
     }
+
 EXIT:
     thread_running = 0;
 

--- a/dsme/mainloop.c
+++ b/dsme/mainloop.c
@@ -104,8 +104,8 @@ mainloop_wakeup_init(void)
     mainloop_wakeup_id = g_io_add_watch(chn,
                                         G_IO_IN | G_IO_ERR | G_IO_HUP | G_IO_NVAL,
                                         mainloop_wakeup_cb, 0);
-cleanup:
 
+cleanup:
     if( chn )
         g_io_channel_unref(chn);
 
@@ -171,4 +171,3 @@ dsme_main_loop_exit_code(void)
 {
     return mainloop_exit_code;
 }
-

--- a/dsme/modulebase.c
+++ b/dsme/modulebase.c
@@ -52,7 +52,6 @@ struct module_t {
     void* handle;
 };
 
-
 /**
    Registered handler information.
 */
@@ -63,7 +62,6 @@ typedef struct {
     handler_fn_t*   callback;
 } msg_handler_info_t;
 
-
 /**
     Sender of a queued message.
 */
@@ -73,7 +71,6 @@ struct endpoint_t {
     struct ucred           ucred; // only valid when conn != 0
 };
 
-
 /**
    Queued message.
 */
@@ -82,7 +79,6 @@ typedef struct {
     const module_t*    to;
     dsmemsg_generic_t* data;
 } queued_msg_t;
-
 
 /**
    Adds a message to list of handlers
@@ -101,7 +97,7 @@ static int add_msghandlers(module_t* module);
 
 static void remove_msghandlers(module_t* module);
 
-/** 
+/**
    Comparison function; matches messages with handlers by message type.
 
    This is callback function of GCompareFunc type.
@@ -112,7 +108,6 @@ static void remove_msghandlers(module_t* module);
    @return negative/zero/positive if a is smaller/equal/larger than b.
 */
 static gint msg_comparator(gconstpointer a, gconstpointer b);
-
 
 /**
    Comparison function; used to sort message handlers.
@@ -138,7 +133,6 @@ static gint sort_comparator(gconstpointer a, gconstpointer b);
  */
 #define compare(v1,v2) (((v1)>(v2))-((v1)<(v2)))
 
-
 /**
    Passes a message to all matching message handlers.
 
@@ -149,7 +143,6 @@ static gint sort_comparator(gconstpointer a, gconstpointer b);
 static int handle_message(endpoint_t*              from,
                           const module_t*          to,
                           const dsmemsg_generic_t* msg);
-
 
 static GSList*     modules       = 0;
 static GSList*     callbacks     = 0;
@@ -169,7 +162,6 @@ static int msg_comparator(gconstpointer a, gconstpointer b)
   return compare(handler->msg_type, msg_type);
 }
 
-
 static gint sort_comparator(gconstpointer a, gconstpointer b)
 {
     const msg_handler_info_t *add = a;
@@ -182,7 +174,6 @@ static gint sort_comparator(gconstpointer a, gconstpointer b)
     return compare(add->msg_type,        old->msg_type) ?:
            compare(add->owner->priority, old->owner->priority) ?: 1;
 }
-
 
 #ifdef OBSOLETE
 /**
@@ -198,7 +189,6 @@ static int name_comparator(const module_t* node, const char* name)
 }
 #endif
 
-
 static int modulebase_add_single_handler(uint32_t        msg_type,
                                          size_t          msg_size,
                                          handler_fn_t*   callback,
@@ -210,12 +200,12 @@ static int modulebase_add_single_handler(uint32_t        msg_type,
     if (!handler) {
         return -1;
     }
-  
+
     handler->msg_type = msg_type;
     handler->msg_size = msg_size;
     handler->callback = callback;
     handler->owner    = owner;
-  
+
     /* Insert into sorted list. */
     callbacks = g_slist_insert_sorted(callbacks,
 				      handler,
@@ -223,7 +213,6 @@ static int modulebase_add_single_handler(uint32_t        msg_type,
 
     return 0;
 }
-
 
 /**
    Locates message handler table from module and adds all message handlers
@@ -236,10 +225,10 @@ static int modulebase_add_single_handler(uint32_t        msg_type,
 static int add_msghandlers(module_t* module)
 {
     module_fn_info_t* msg_handler_ptr;
-  
+
     if (!module)
         return -1;
-  
+
     for (msg_handler_ptr = (module_fn_info_t*)dlsym(module->handle,
                                                     "message_handlers");
 	 msg_handler_ptr && msg_handler_ptr->callback;
@@ -254,7 +243,6 @@ static int add_msghandlers(module_t* module)
 
     return 0;
 }
-
 
 /**
    This function is called when some module is unloaded.
@@ -279,7 +267,6 @@ static void remove_msghandlers(module_t* module)
         }
     }
 }
-
 
 static const module_t* currently_handling_module = 0;
 
@@ -421,7 +408,6 @@ void endpoint_send(endpoint_t* recipient, const void* msg)
   endpoint_send_with_extra(recipient, msg, 0, 0);
 }
 
-
 const struct ucred* endpoint_ucred(const endpoint_t* sender)
 {
   const struct ucred* u = 0;
@@ -551,7 +537,6 @@ void endpoint_free(endpoint_t* endpoint)
   free(endpoint);
 }
 
-
 void modulebase_process_message_queue(void)
 {
     while (message_queue) {
@@ -573,7 +558,6 @@ void modulebase_process_message_queue(void)
     DSM_MSGTYPE_IDLE idle = DSME_MSG_INIT(DSM_MSGTYPE_IDLE);
     handle_message(&from, 0, &idle);
 }
-
 
 static int handle_message(endpoint_t*              from,
                           const module_t*          to,
@@ -608,7 +592,6 @@ static int handle_message(endpoint_t*              from,
 
   return 0;
 }
-
 
 bool modulebase_unload_module(module_t* module)
 {
@@ -657,7 +640,6 @@ bool modulebase_unload_module(module_t* module)
 
     return unloaded;
 }
-
 
 module_t* modulebase_load_module(const char* filename, int priority)
 {
@@ -730,10 +712,9 @@ error:
     }
 
     if (dlhandle) dlclose(dlhandle);
-  
+
   return 0;
 }
-
 
 bool modulebase_init(const struct _GSList* module_names)
 {
@@ -750,7 +731,6 @@ bool modulebase_init(const struct _GSList* module_names)
 
     return true;
 }
-
 
 const char* module_name(const module_t* module)
 {

--- a/dsme/oom.c
+++ b/dsme/oom.c
@@ -41,7 +41,7 @@
 #define OOM_PROTECT_VALUE_NEW   (-1000)
 #define OOM_UNPROTECT_VALUE     0
 typedef enum {oom_protected, oom_unprotected} oom_mode;
-  
+
 static bool set_oom_protection_mode(oom_mode mode)
 {
   FILE* file = 0;
@@ -54,7 +54,7 @@ static bool set_oom_protection_mode(oom_mode mode)
   if (stat(OOM_ADJ_PATH_NEW, &st) == 0) {
     oom_path = (char*)new_path;
   } else {
-    oom_path = (char*)old_path; 
+    oom_path = (char*)old_path;
   }
 
   if (mode == oom_protected) {
@@ -97,7 +97,7 @@ bool unprotect_from_oom(void)
 
 bool adjust_oom(int oom_adj)
 {
-  /* This function is not used anywhere, but we keep it anyhow 
+  /* This function is not used anywhere, but we keep it anyhow
    * Actual value can not be set anymore but only protected/unprotected
    */
   if (oom_adj < 0) {

--- a/dsme/timers.c
+++ b/dsme/timers.c
@@ -38,7 +38,6 @@ typedef struct
     guint                  tg_interval;
     dsme_timer_callback_t  tg_callback;
     void                  *tg_data;
-
 } timergate_t;
 
 static void

--- a/dsme/utility.c
+++ b/dsme/utility.c
@@ -157,7 +157,6 @@ dsme_get_crypt_device_for_home(void)
     cdev = work, work = 0;
 
 EXIT:
-
     dsme_free_crypt_device(work);
 
     return cdev;

--- a/getbootstate/getbootstate.c
+++ b/getbootstate/getbootstate.c
@@ -71,7 +71,6 @@
 
 #define GETBOOTSTATE_PREFIX "getbootstate: "
 
-
 static bool forcemode = false;
 
 static void log_msg(const char* format, ...) __attribute__ ((format (printf, 1, 2)));
@@ -147,7 +146,6 @@ static void log_msg(const char* format, ...)
     errno = saved;
 }
 
-
 static int save_state(const char* state)
 {
     FILE* saved_state_file;
@@ -212,7 +210,6 @@ EXIT:
 
     return ret ?: strdup("USER");
 }
-
 
 static void write_loop_counts(unsigned boots, unsigned wd_resets, time_t when)
 {
@@ -410,14 +407,12 @@ int main(int argc, char** argv)
         }
     }
 
-
     if(get_bootreason(bootreason, MAX_BOOTREASON_LEN) < 0) {
         log_msg("Bootreason could not be read\n");
         return_bootstate("MALF",
                          "SOFTWARE bootloader no bootreason",
                          COUNT_BOOTS);
     }
-
 
     if (!strcmp(bootreason, BOOT_REASON_SEC_VIOLATION)) {
         log_msg("Security violation\n");
@@ -427,7 +422,6 @@ int main(int argc, char** argv)
                          COUNT_BOOTS);
     }
 
-
     if (!strcmp(bootreason, BOOT_REASON_POWER_ON_RESET) ||
         !strcmp(bootreason, BOOT_REASON_SWDG_TIMEOUT)   ||
         !strcmp(bootreason, BOOT_REASON_32K_WDG_TIMEOUT))
@@ -436,7 +430,6 @@ int main(int argc, char** argv)
         const char *new_state = "USER";
 
         char *saved_state = get_saved_state();
-
 
         log_msg("Unexpected reset occured (%s). "
                   "Previous bootstate=%s - selecting %s\n",

--- a/include/dsme/dsmesock.h
+++ b/include/dsme/dsmesock.h
@@ -23,7 +23,6 @@
    License along with Dsme.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DSMESOCK_H
 #define DSMESOCK_H
 
@@ -47,7 +46,6 @@ struct dsmesock_connection_t;
    * @{
    */
 
-
 /**
    A callback for client sockets ready to be read.
 
@@ -63,7 +61,6 @@ typedef bool dsmesock_callback(struct dsmesock_connection_t* conn);
 */
 int dsmesock_listen(dsmesock_callback* read_and_queue);
 
-
 /**
    Close listening socket
    Close all client sockets
@@ -71,7 +68,6 @@ int dsmesock_listen(dsmesock_callback* read_and_queue);
    @return nothing
 */
 void dsmesock_shutdown(void);
-
 
   /**
    * @}
@@ -81,6 +77,5 @@ void dsmesock_shutdown(void);
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif

--- a/include/dsme/logging.h
+++ b/include/dsme/logging.h
@@ -90,11 +90,13 @@ void dsme_log_clear_rules(void);
 bool dsme_log_p_ (int level, const char *file, const char *func);
 void dsme_log_queue(int level, const char *file, const char *func, const char *fmt, ...) __attribute__((format(printf,4,5)));
 
-#  define dsme_log(LEV_, FMT_, ARGS_...) \
+# define dsme_log_p(LEV_) dsme_log_p_(LEV_, __FILE__, __FUNCTION__)
+
+# define dsme_log(LEV_, FMT_, ARGS_...) \
      do {\
          if( dsme_log_p_(LEV_, __FILE__, __FUNCTION__) ) {\
              dsme_log_queue(LEV_, __FILE__, __FUNCTION__, FMT_, ## ARGS_);\
          }\
-     }while(0)
+     } while( 0 )
 
 #endif /* DSME_LOGGING_H */

--- a/include/dsme/logging.h
+++ b/include/dsme/logging.h
@@ -45,7 +45,6 @@ typedef enum {
     LOG_METHOD_FILE    /* Output messages to the file */
 } log_method;
 
-
 /* libdsm/dsmesocke IPC */
 typedef struct
 {

--- a/include/dsme/modulebase.h
+++ b/include/dsme/modulebase.h
@@ -66,7 +66,6 @@ int modulebase_shutdown(void);
 */
 module_t* modulebase_load_module(const char* filename, int priority);
 
-
 /**
    Unloads module.
 
@@ -86,7 +85,6 @@ void modulebase_process_message_queue(void);
 
 const module_t* modulebase_current_module(void);
 const module_t* modulebase_enter_module(const module_t* module);
-
 
 enum {
     /* NOTE: dsme message types are defined in:

--- a/include/dsme/modules.h
+++ b/include/dsme/modules.h
@@ -57,7 +57,6 @@ extern "C" {
 #define DSME_HANDLER_BINDING(T) \
   { DSME_MSG_ID_(T), T ## _HANDLER1_, sizeof(T) }
 
-
 typedef struct endpoint_t endpoint_t;
 
 struct dsmesock_connection_t; // TODO: remove
@@ -67,7 +66,6 @@ struct dsmesock_connection_t; // TODO: remove
 */
 typedef void (handler_fn_t)(endpoint_t* sender, const dsmemsg_generic_t* msg);
 
-
 /**
    Handler information entry in module.
 */
@@ -76,7 +74,6 @@ typedef struct {
     handler_fn_t* callback;
     size_t        msg_size;
 } module_fn_info_t;
-
 
 /**
    Module initialization function type.
@@ -129,7 +126,6 @@ bool endpoint_same(const endpoint_t* a, const endpoint_t* b);
 bool endpoint_is_dsme(const endpoint_t* endpoint);
 endpoint_t* endpoint_copy(const endpoint_t* endpoint);
 void endpoint_free(endpoint_t* endpoint);
-
 
 #ifdef __cplusplus
 }

--- a/modules/abootsettings.c
+++ b/modules/abootsettings.c
@@ -139,19 +139,19 @@ static void get_locked(const DsmeDbusMessage* request,
 {
     int unlocked = 0;
 
-    dsme_log(LOG_DEBUG, PFIX"get_locked");
+    dsme_log(LOG_DEBUG, PFIX "get_locked");
 
     // Read device info and get unlocked value.
     if( !get_unlocked_value(&unlocked) )
     {
-        dsme_log(LOG_ERR, PFIX"Error: Failed to read dev info");
+        dsme_log(LOG_ERR, PFIX "Error: Failed to read dev info");
 
         *reply = dsme_dbus_reply_error( request, DBUS_ERROR_IO_ERROR,
                                        "Failed to read device info" );
         return;
     }
 
-    dsme_log(LOG_DEBUG, PFIX"return locked to client");
+    dsme_log(LOG_DEBUG, PFIX "return locked to client");
 
     *reply = dsme_dbus_reply_new(request);
     // Since this function returns locked status,
@@ -172,7 +172,7 @@ static void set_locked(const DsmeDbusMessage* request,
 {
     int locked = -1;
 
-    dsme_log(LOG_DEBUG, PFIX"set_locked");
+    dsme_log(LOG_DEBUG, PFIX "set_locked");
 
     // Get input value
     locked = dsme_dbus_message_get_int(request);
@@ -180,7 +180,7 @@ static void set_locked(const DsmeDbusMessage* request,
     // Check that input value is 0 or 1.
     if( locked != 0 && locked != 1 )
     {
-        dsme_log(LOG_ERR, PFIX"Error: Invalid input value");
+        dsme_log(LOG_ERR, PFIX "Error: Invalid input value");
 
         *reply = dsme_dbus_reply_error(request, DBUS_ERROR_INVALID_ARGS,
                                        "Invalid input value");
@@ -191,14 +191,14 @@ static void set_locked(const DsmeDbusMessage* request,
     // Since we have lock value we need to invert it.
     if( !set_unlocked_value(!locked) )
     {
-        dsme_log(LOG_ERR, PFIX"Error: Failed to write dev info");
+        dsme_log(LOG_ERR, PFIX "Error: Failed to write dev info");
 
         *reply = dsme_dbus_reply_error(request, DBUS_ERROR_IO_ERROR,
                                        "Failed to write device info");
         return;
     }
 
-    dsme_log(LOG_DEBUG, PFIX"return OK");
+    dsme_log(LOG_DEBUG, PFIX "return OK");
 
     *reply = dsme_dbus_reply_new(request);
     // Return message to client.
@@ -238,12 +238,12 @@ static const dsme_dbus_binding_t dbus_methods_array[] =
 
 DSME_HANDLER(DSM_MSGTYPE_DBUS_CONNECTED, client, msg)
 {
-    dsme_log(LOG_DEBUG, PFIX"DSM_MSGTYPE_DBUS_CONNECTED");
+    dsme_log(LOG_DEBUG, PFIX "DSM_MSGTYPE_DBUS_CONNECTED");
 
     // Check that plug-in is initialized.
     if( abootsettings_init )
     {
-        dsme_log(LOG_DEBUG, PFIX"bind methods");
+        dsme_log(LOG_DEBUG, PFIX "bind methods");
         dsme_dbus_bind_methods(&dbus_methods_bound,
                                abootsettings_service,
                                abootsettings_path,
@@ -254,7 +254,7 @@ DSME_HANDLER(DSM_MSGTYPE_DBUS_CONNECTED, client, msg)
 
 DSME_HANDLER(DSM_MSGTYPE_DBUS_DISCONNECT, client, msg)
 {
-    dsme_log(LOG_DEBUG, PFIX"DSM_MSGTYPE_DBUS_DISCONNECT");
+    dsme_log(LOG_DEBUG, PFIX "DSM_MSGTYPE_DBUS_DISCONNECT");
 }
 
 module_fn_info_t message_handlers[] =
@@ -272,7 +272,7 @@ void module_init(module_t* handle)
 {
     GKeyFile* key_file = NULL;
 
-    dsme_log(LOG_DEBUG, PFIX"module_init");
+    dsme_log(LOG_DEBUG, PFIX "module_init");
 
     key_file = g_key_file_new();
 
@@ -296,14 +296,14 @@ void module_init(module_t* handle)
             }
             else
             {
-                dsme_log(LOG_ERR, PFIX"%s: deviceinfo partition not defined",
+                dsme_log(LOG_ERR, PFIX "%s: deviceinfo partition not defined",
                          ABOOTSET_INI);
             }
         }
         else
         {
             dsme_log(error->code == G_FILE_ERROR_NOENT ? LOG_DEBUG : LOG_ERR,
-                     PFIX"%s: INI file could not be loaded: %s",
+                     PFIX "%s: INI file could not be loaded: %s",
                      ABOOTSET_INI, error->message);
         }
 
@@ -311,12 +311,12 @@ void module_init(module_t* handle)
         g_clear_error(&error);
     }
 
-    dsme_log(LOG_DEBUG, PFIX"module_init done");
+    dsme_log(LOG_DEBUG, PFIX "module_init done");
 }
 
 void module_fini(void)
 {
-    dsme_log(LOG_DEBUG, PFIX"module_fini");
+    dsme_log(LOG_DEBUG, PFIX "module_fini");
 
     dsme_dbus_unbind_methods(&dbus_methods_bound,
                              abootsettings_service,
@@ -341,7 +341,7 @@ void module_fini(void)
  */
 static bool open_partition(int flag)
 {
-    dsme_log(LOG_DEBUG, PFIX"open_partition");
+    dsme_log(LOG_DEBUG, PFIX "open_partition");
 
     // If we have file descriptor open, return true.
     if( partition != -1 )
@@ -358,12 +358,12 @@ static bool open_partition(int flag)
 
     if( partition == -1 )
     {
-        dsme_log(LOG_ERR, PFIX"Error: Can't open partition (%d)",
+        dsme_log(LOG_ERR, PFIX "Error: Can't open partition (%d)",
             partition);
         return false;
     }
 
-    dsme_log(LOG_DEBUG, PFIX"Partition open successful");
+    dsme_log(LOG_DEBUG, PFIX "Partition open successful");
     return true;
 }
 
@@ -375,7 +375,7 @@ static void close_partition()
 {
     if( partition != -1 )
     {
-        dsme_log(LOG_DEBUG, PFIX"Close partition (%d)", partition);
+        dsme_log(LOG_DEBUG, PFIX "Close partition (%d)", partition);
         close(partition);
         partition = -1;
     }
@@ -393,11 +393,11 @@ static bool set_emmc_block_size()
     int ret = 0;
     block_size = 0;
 
-    dsme_log(LOG_DEBUG, PFIX"set_emmc_block_size");
+    dsme_log(LOG_DEBUG, PFIX "set_emmc_block_size");
 
     if( partition == -1 )
     {
-        dsme_log(LOG_ERR, PFIX"Error: partition not open");
+        dsme_log(LOG_ERR, PFIX "Error: partition not open");
         return false;
     }
 
@@ -405,13 +405,13 @@ static bool set_emmc_block_size()
 
     if( ret < 0 || block_size <= 0 )
     {
-        dsme_log(LOG_ERR, PFIX"Error: ioctl = %d, block size = %d",
+        dsme_log(LOG_ERR, PFIX "Error: ioctl = %d, block size = %d",
             ret, block_size);
         block_size = 0;
         return false;
     }
 
-    dsme_log(LOG_DEBUG, PFIX"block size = %d", block_size);
+    dsme_log(LOG_DEBUG, PFIX "block size = %d", block_size);
 
     return true;
 }
@@ -427,24 +427,24 @@ static bool set_file_offset()
     off_t partition_size = 0;
     devinfo_data_offset = 0;
 
-    dsme_log(LOG_DEBUG, PFIX"set_file_offset");
+    dsme_log(LOG_DEBUG, PFIX "set_file_offset");
 
     if( partition == -1 )
     {
-        dsme_log(LOG_ERR, PFIX"Error: partition not open");
+        dsme_log(LOG_ERR, PFIX "Error: partition not open");
         return false;
     }
 
     if( !set_emmc_block_size() )
     {
-        dsme_log(LOG_ERR, PFIX"Error: failed to get block size");
+        dsme_log(LOG_ERR, PFIX "Error: failed to get block size");
         return false;
     }
 
     // Get partition size.
     partition_size = lseek(partition, 0, SEEK_END);
 
-    dsme_log(LOG_DEBUG, PFIX"Partition size = %llu",
+    dsme_log(LOG_DEBUG, PFIX "Partition size = %llu",
         (unsigned long long)partition_size);
 
     // Set file pointer to start.
@@ -452,7 +452,7 @@ static bool set_file_offset()
 
     if( partition_size <= block_size )
     {
-        dsme_log(LOG_ERR, PFIX"Error: Partition size");
+        dsme_log(LOG_ERR, PFIX "Error: Partition size");
         return false;
     }
 
@@ -461,10 +461,10 @@ static bool set_file_offset()
 
     if( devinfo_data_offset <= 0 )
     {
-         dsme_log(LOG_ERR, PFIX"Error: offset null");
+         dsme_log(LOG_ERR, PFIX "Error: offset null");
          return false;
     }
-    dsme_log(LOG_DEBUG, PFIX"Offset = %llu",
+    dsme_log(LOG_DEBUG, PFIX "Offset = %llu",
         (unsigned long long)devinfo_data_offset);
 
     return true;
@@ -482,7 +482,7 @@ static int encode_device_info(device_info *dev, char* buf)
     int size = 0;
     int32_t value = 0;
 
-    dsme_log(LOG_DEBUG, PFIX"decode_device_info");
+    dsme_log(LOG_DEBUG, PFIX "decode_device_info");
 
     if( buf == NULL || dev == NULL )
     {
@@ -579,11 +579,11 @@ static int encode_device_info(device_info *dev, char* buf)
     else
     {
         // No support for this version.
-        dsme_log(LOG_ERR, PFIX"Error: This version not supported");
+        dsme_log(LOG_ERR, PFIX "Error: This version not supported");
         return 0;
     }
 
-    dsme_log(LOG_DEBUG, PFIX"encoded size = %d", size);
+    dsme_log(LOG_DEBUG, PFIX "encoded size = %d", size);
 
     return size;
 }
@@ -600,13 +600,13 @@ static bool decode_device_info(device_info* dev, char* buf)
     int size = 0;
     int32_t value = 0;
 
-    dsme_log(LOG_DEBUG, PFIX"decode_device_info");
+    dsme_log(LOG_DEBUG, PFIX "decode_device_info");
 
     // Copy version number
 
     memcpy(&value, buf, sizeof value);
     size = sizeof value;
-    dsme_log(LOG_DEBUG, PFIX"Device info version (%d)", value);
+    dsme_log(LOG_DEBUG, PFIX "Device info version (%d)", value);
 
     // Save current device info version
     device_info_version = value;
@@ -625,7 +625,7 @@ static bool decode_device_info(device_info* dev, char* buf)
         // Check that we have magic
         if( memcmp(dev->magic, DEVICE_MAGIC, DEVICE_MAGIC_SIZE) )
         {
-            dsme_log(LOG_ERR, PFIX"Device magic not found");
+            dsme_log(LOG_ERR, PFIX "Device magic not found");
             return false;
         }
 
@@ -642,7 +642,7 @@ static bool decode_device_info(device_info* dev, char* buf)
         }
         else
         {
-            dsme_log(LOG_ERR, PFIX"is_unlocked value not in range");
+            dsme_log(LOG_ERR, PFIX "is_unlocked value not in range");
             return false;
         }
 
@@ -657,7 +657,7 @@ static bool decode_device_info(device_info* dev, char* buf)
         }
         else
         {
-            dsme_log(LOG_ERR, PFIX"is_tampered value not in range");
+            dsme_log(LOG_ERR, PFIX "is_tampered value not in range");
             return false;
         }
 
@@ -674,7 +674,7 @@ static bool decode_device_info(device_info* dev, char* buf)
             }
             else
             {
-                dsme_log(LOG_ERR, PFIX"is_unlock_critical value not in range");
+                dsme_log(LOG_ERR, PFIX "is_unlock_critical value not in range");
                 return false;
             }
         }
@@ -691,7 +691,7 @@ static bool decode_device_info(device_info* dev, char* buf)
             }
             else
             {
-                dsme_log(LOG_ERR, PFIX"is_verified value not in range");
+                dsme_log(LOG_ERR, PFIX "is_verified value not in range");
                 return false;
             }
         }
@@ -707,7 +707,7 @@ static bool decode_device_info(device_info* dev, char* buf)
         }
         else
         {
-            dsme_log(LOG_ERR, PFIX"charger_screen value not in range");
+            dsme_log(LOG_ERR, PFIX "charger_screen value not in range");
             return false;
         }
 
@@ -745,7 +745,7 @@ static bool decode_device_info(device_info* dev, char* buf)
             }
             else
             {
-                dsme_log(LOG_ERR, PFIX"verity_mode value not in range");
+                dsme_log(LOG_ERR, PFIX "verity_mode value not in range");
                 return false;
             }
 
@@ -759,7 +759,7 @@ static bool decode_device_info(device_info* dev, char* buf)
     }
     else
     {
-      dsme_log(LOG_ERR, PFIX"Error: Version not supported");
+      dsme_log(LOG_ERR, PFIX "Error: Version not supported");
       return false;
     }
 }
@@ -773,25 +773,25 @@ static bool read_device_info_from_disk()
     char data[DEVINFO_BUF_SIZE];
     memset(data, 0, DEVINFO_BUF_SIZE);
 
-    dsme_log(LOG_DEBUG, PFIX"read_device_info_from_disk");
+    dsme_log(LOG_DEBUG, PFIX "read_device_info_from_disk");
 
     // Set file pointer to offset e.g. last block of partition.
     if( lseek(partition, devinfo_data_offset, SEEK_SET) < 0 )
     {
-        dsme_log(LOG_ERR, PFIX"Error: Failed to seek to offser");
+        dsme_log(LOG_ERR, PFIX "Error: Failed to seek to offser");
         return false;
     }
 
     if( block_size > DEVINFO_BUF_SIZE )
     {
-        dsme_log(LOG_ERR, PFIX"Error: block size too big");
+        dsme_log(LOG_ERR, PFIX "Error: block size too big");
         return false;
     }
 
     // Read device info.
     if( read(partition, &data, block_size) < block_size )
     {
-        dsme_log(LOG_ERR, PFIX"Error: Failed to read");
+        dsme_log(LOG_ERR, PFIX "Error: Failed to read");
         return false;
     }
 
@@ -809,19 +809,19 @@ static bool write_device_info_to_disk()
     char* data_ptr = &data[0];
     memset(data, 0, DEVINFO_BUF_SIZE);
 
-    dsme_log(LOG_DEBUG, PFIX"write_device_info");
+    dsme_log(LOG_DEBUG, PFIX "write_device_info");
 
     // Encode device info to buffer.
     if( encode_device_info(&device, data) == 0 )
     {
-        dsme_log(LOG_ERR, PFIX"Error: encoded failed");
+        dsme_log(LOG_ERR, PFIX "Error: encoded failed");
         return false;
     }
 
     // Set file pointer to last block of aboot partition.
     if( lseek(partition, devinfo_data_offset, SEEK_SET) < 0 )
     {
-        dsme_log(LOG_ERR, PFIX"Error: failed to seek offset");
+        dsme_log(LOG_ERR, PFIX "Error: failed to seek offset");
         return false;
     }
 
@@ -834,14 +834,14 @@ static bool write_device_info_to_disk()
                                                byte_count));
         if( written < 0 )
         {
-            dsme_log(LOG_ERR, PFIX"Error: failed to write: %m");
+            dsme_log(LOG_ERR, PFIX "Error: failed to write: %m");
             return false;
         }
         data_ptr += written;
         byte_count -= written;
     }
 
-    dsme_log(LOG_DEBUG, PFIX"Device info write successful");
+    dsme_log(LOG_DEBUG, PFIX "Device info write successful");
     return true;
 }
 
@@ -853,7 +853,7 @@ static bool get_unlocked_value(int* unlocked)
  {
     bool retOk = false;
 
-    dsme_log(LOG_DEBUG, PFIX"get_unlocked_value");
+    dsme_log(LOG_DEBUG, PFIX "get_unlocked_value");
 
     if( !open_partition(O_RDONLY) )
     {
@@ -868,7 +868,7 @@ static bool get_unlocked_value(int* unlocked)
             *unlocked = (int)device.is_unlocked;
             retOk = true;
 
-            dsme_log(LOG_DEBUG, PFIX" [ is_unlocked = %d ]",
+            dsme_log(LOG_DEBUG, PFIX " [ is_unlocked = %d ]",
                 (int)device.is_unlocked);
         }
     }
@@ -885,7 +885,7 @@ static bool set_unlocked_value(int value)
  {
     bool retOk = false;
 
-    dsme_log(LOG_DEBUG, PFIX"set_unlocked_value");
+    dsme_log(LOG_DEBUG, PFIX "set_unlocked_value");
 
     if( !open_partition(O_RDWR) )
     {
@@ -900,7 +900,7 @@ static bool set_unlocked_value(int value)
         {
             device.is_unlocked = value;
 
-            dsme_log(LOG_DEBUG, PFIX" [ is_unlocked = %d ]",
+            dsme_log(LOG_DEBUG, PFIX " [ is_unlocked = %d ]",
                 (int)device.is_unlocked );
 
             if( write_device_info_to_disk() )

--- a/modules/abootsettings.c
+++ b/modules/abootsettings.c
@@ -157,7 +157,6 @@ static void get_locked(const DsmeDbusMessage* request,
     // Since this function returns locked status,
     // we need to invert unlocked value.
     dsme_dbus_message_append_int(*reply, !unlocked);
-
 }
 
 /* -------------------------------------------------------------------------

--- a/modules/alarmtracker.c
+++ b/modules/alarmtracker.c
@@ -202,7 +202,7 @@ alarmtracker_alarmtime_schedule_save(void)
     msg.req.pid     = 0;
     msg.data        = 0;
 
-    dsme_log(LOG_DEBUG, PFIX"scheduled status save");
+    dsme_log(LOG_DEBUG, PFIX "scheduled status save");
     modules_broadcast_internally(&msg);
 }
 
@@ -219,19 +219,19 @@ alarmtracker_alarmtime_load(void)
     if( !(fh = fopen(ALARM_STATE_FILE, "r")) ) {
         /* Silently ignore non-existing cache file */
         if( errno != ENOENT )
-            dsme_log(LOG_WARNING, PFIX"%s: can't open: %m",
+            dsme_log(LOG_WARNING, PFIX "%s: can't open: %m",
                      ALARM_STATE_FILE);
         goto EXIT;
     }
 
     long data = 0;
     if( errno = 0, fscanf(fh, "%ld", &data) != 1 ) {
-        dsme_log(LOG_DEBUG, PFIX"%s: read error: %m", ALARM_STATE_FILE);
+        dsme_log(LOG_DEBUG, PFIX "%s: read error: %m", ALARM_STATE_FILE);
         goto EXIT;
     }
 
     alarmtracker_alarmtime_cached  = (time_t)data;
-    dsme_log(LOG_DEBUG, PFIX"Alarm queue head restored: %ld",
+    dsme_log(LOG_DEBUG, PFIX "Alarm queue head restored: %ld",
              alarmtracker_alarmtime_current);
 
 EXIT:
@@ -248,28 +248,28 @@ alarmtracker_alarmtime_save(void)
 {
     FILE *fh = 0;
 
-    dsme_log(LOG_DEBUG, PFIX"execute status save");
+    dsme_log(LOG_DEBUG, PFIX "execute status save");
 
     if( alarmtracker_alarmtime_cached == alarmtracker_alarmtime_current ) {
-        dsme_log(LOG_DEBUG, PFIX"%s is up to date",
+        dsme_log(LOG_DEBUG, PFIX "%s is up to date",
                  ALARM_STATE_FILE);
         goto EXIT;
     }
 
     if( !(fh = fopen(ALARM_STATE_FILE_TMP, "w+")) ) {
-        dsme_log(LOG_WARNING, PFIX"%s: can't open: %m",
+        dsme_log(LOG_WARNING, PFIX "%s: can't open: %m",
                  ALARM_STATE_FILE_TMP);
         goto EXIT;
     }
 
     if( fprintf(fh, "%ld\n", alarmtracker_alarmtime_current) < 0) {
-        dsme_log(LOG_WARNING, PFIX"%s: can't write: %m",
+        dsme_log(LOG_WARNING, PFIX "%s: can't write: %m",
                  ALARM_STATE_FILE_TMP);
         goto EXIT;
     }
 
     if( fflush(fh) == EOF ) {
-        dsme_log(LOG_WARNING, PFIX"%s: can't flush: %m",
+        dsme_log(LOG_WARNING, PFIX "%s: can't flush: %m",
                  ALARM_STATE_FILE_TMP);
         goto EXIT;
     }
@@ -277,12 +277,12 @@ alarmtracker_alarmtime_save(void)
     fclose(fh), fh = 0;
 
     if( rename(ALARM_STATE_FILE_TMP, ALARM_STATE_FILE) == -1 ) {
-        dsme_log(LOG_WARNING, PFIX"%s: can't update: %m",
+        dsme_log(LOG_WARNING, PFIX "%s: can't update: %m",
                  ALARM_STATE_FILE);
         goto EXIT;
     }
 
-    dsme_log(LOG_DEBUG, PFIX"%s updated", ALARM_STATE_FILE);
+    dsme_log(LOG_DEBUG, PFIX "%s updated", ALARM_STATE_FILE);
     alarmtracker_alarmtime_cached = alarmtracker_alarmtime_current;
 
 EXIT:
@@ -299,7 +299,7 @@ alarmtracker_alarmtime_update(time_t alarmtime)
 {
     if( alarmtracker_alarmtime_current != alarmtime ) {
         char prev[32], curr[32];
-        dsme_log(LOG_DEBUG, PFIX"alarmtime: %s-> %s",
+        dsme_log(LOG_DEBUG, PFIX "alarmtime: %s-> %s",
                  alarmtime_repr(alarmtracker_alarmtime_current,
                                 prev, sizeof prev),
                  alarmtime_repr(alarmtime, curr, sizeof curr));
@@ -359,7 +359,7 @@ alarmtracker_alarmstate_broadcast(void)
 
         msg.alarm_set = alarmtracker_alarmstate_current;
 
-        dsme_log(LOG_DEBUG, PFIX"broadcasting alarm state: %s",
+        dsme_log(LOG_DEBUG, PFIX "broadcasting alarm state: %s",
                  alarmtracker_alarmstate_current ? "set" : "not set");
 
         /* inform state module about changed alarm state */
@@ -384,7 +384,7 @@ alarmtracker_alarmstate_schedule_evaluate(int delay)
         alarmtracker_alarmstate_evaluate_id =
             dsme_create_timer_seconds(delay,
                                       alarmtracker_alarmstate_evaluate_cb, 0);
-        dsme_log(LOG_DEBUG, PFIX"evaluate again in %d s", delay);
+        dsme_log(LOG_DEBUG, PFIX "evaluate again in %d s", delay);
     }
 }
 
@@ -396,7 +396,7 @@ alarmtracker_alarmstate_cancel_evaluate(void)
     if( alarmtracker_alarmstate_evaluate_id ) {
         dsme_destroy_timer(alarmtracker_alarmstate_evaluate_id),
             alarmtracker_alarmstate_evaluate_id = 0;
-        dsme_log(LOG_DEBUG, PFIX"re-evaluate canceled");
+        dsme_log(LOG_DEBUG, PFIX "re-evaluate canceled");
     }
 }
 
@@ -411,7 +411,7 @@ alarmtracker_alarmstate_evaluate_cb(void *aptr)
 {
     (void)aptr;
 
-    dsme_log(LOG_DEBUG, PFIX"re-evaluate triggered");
+    dsme_log(LOG_DEBUG, PFIX "re-evaluate triggered");
 
     alarmtracker_alarmstate_evaluate_id = 0;
 
@@ -464,7 +464,7 @@ alarmtracker_alarmstate_evaluate(void)
     }
 
     if( alarmtracker_alarmstate_current != alarm_set ) {
-        dsme_log(LOG_DEBUG, PFIX"alarmstate: %d -> %d",
+        dsme_log(LOG_DEBUG, PFIX "alarmstate: %d -> %d",
                  alarmtracker_alarmstate_current,
                  alarm_set);
         alarmtracker_alarmstate_current = alarm_set;
@@ -495,7 +495,7 @@ static void
 alarmtracker_dsmestate_update(dsme_state_t state)
 {
     if( alarmtracker_dsmestate_current != state ) {
-        dsme_log(LOG_DEBUG, PFIX"dsme_state: %s -> %s",
+        dsme_log(LOG_DEBUG, PFIX "dsme_state: %s -> %s",
                  dsme_state_repr(alarmtracker_dsmestate_current),
                  dsme_state_repr(state));
         alarmtracker_dsmestate_current = state;
@@ -565,13 +565,13 @@ DSME_HANDLER(DSM_MSGTYPE_WAKEUP, client, msg)
 
 DSME_HANDLER(DSM_MSGTYPE_DBUS_CONNECTED, client, msg)
 {
-    dsme_log(LOG_DEBUG, PFIX"DBUS_CONNECTED");
+    dsme_log(LOG_DEBUG, PFIX "DBUS_CONNECTED");
     dsme_dbus_bind_signals(&dbus_signals_bound, dbus_signals_array);
 }
 
 DSME_HANDLER(DSM_MSGTYPE_DBUS_DISCONNECT, client, msg)
 {
-    dsme_log(LOG_DEBUG, PFIX"DBUS_DISCONNECT");
+    dsme_log(LOG_DEBUG, PFIX "DBUS_DISCONNECT");
 }
 
 DSME_HANDLER(DSM_MSGTYPE_STATE_QUERY, client, req)
@@ -608,7 +608,7 @@ module_init(module_t *handle)
      * Instead, wait for DSM_MSGTYPE_DBUS_CONNECTED.
      */
 
-    dsme_log(LOG_DEBUG, PFIX"loading plugin");
+    dsme_log(LOG_DEBUG, PFIX "loading plugin");
 
     alarmtracker_alarmtime_load();
     alarmtracker_dsmestate_query();
@@ -619,7 +619,7 @@ module_init(module_t *handle)
 void
 module_fini(void)
 {
-    dsme_log(LOG_DEBUG, PFIX"unloading plugin");
+    dsme_log(LOG_DEBUG, PFIX "unloading plugin");
 
     dsme_dbus_unbind_signals(&dbus_signals_bound, dbus_signals_array);
     alarmtracker_alarmtime_save();

--- a/modules/alarmtracker.c
+++ b/modules/alarmtracker.c
@@ -286,7 +286,6 @@ alarmtracker_alarmtime_save(void)
     alarmtracker_alarmtime_cached = alarmtracker_alarmtime_current;
 
 EXIT:
-
     if( fh )
         fclose(fh);
 
@@ -530,7 +529,6 @@ alarmtracker_dbus_next_bootup_event_cb(const DsmeDbusMessage *ind)
     time_t alarmtime = dsme_dbus_message_get_int(ind);
 
     alarmtracker_alarmtime_update(alarmtime);
-
 }
 
 /** Array of dbus signal handlers to install */

--- a/modules/batterytracker.c
+++ b/modules/batterytracker.c
@@ -459,7 +459,6 @@ EXIT:
  */
 static const symbol_t dsme_charger_state_lut[] =
 {
-
     { MCE_CHARGER_STATE_UNKNOWN, DSME_CHARGER_STATE_UNKNOWN },
     { MCE_CHARGER_STATE_ON,      DSME_CHARGER_STATE_ON      },
     { MCE_CHARGER_STATE_OFF,     DSME_CHARGER_STATE_OFF     },
@@ -990,7 +989,6 @@ xmce_running_set(bool running)
     }
 
 cleanup:
-
     return;
 }
 
@@ -1027,7 +1025,6 @@ xmce_tracking_init(void)
     xmce_send_name_owner_query();
 
 cleanup:
-
     return;
 }
 
@@ -1053,7 +1050,6 @@ xmce_tracking_quit(void)
     xmce_forget_battery_level_query();
 
 cleanup:
-
     return;
 }
 
@@ -1120,7 +1116,6 @@ xmce_name_owner_filter_cb(DBusConnection *con, DBusMessage *msg, void *aptr)
     }
 
 cleanup:
-
     dbus_error_free(&err);
 
     modulebase_enter_module(caller);
@@ -1171,7 +1166,6 @@ xmce_name_owner_reply_cb(DBusPendingCall *pc, void *aptr)
     xmce_running_set(dta && *dta);
 
 cleanup:
-
     if( rsp ) dbus_message_unref(rsp);
 
     dbus_error_free(&err);
@@ -1240,7 +1234,6 @@ xmce_send_name_owner_query(void)
     res = true;
 
 cleanup:
-
     if( res )
         dsme_log(LOG_DEBUG, PFIX"mce name owner query sent");
     else
@@ -1301,7 +1294,6 @@ xmce_usb_cable_state_reply_cb(DBusPendingCall *pc, void *aptr)
     dsme_usb_cable_state_set(state);
 
 cleanup:
-
     if( rsp )
         dbus_message_unref(rsp);
 
@@ -1421,7 +1413,6 @@ xmce_charger_state_reply_cb(DBusPendingCall *pc, void *aptr)
     dsme_charger_state_set(state);
 
 cleanup:
-
     if( rsp )
         dbus_message_unref(rsp);
 
@@ -1541,7 +1532,6 @@ xmce_battery_status_reply_cb(DBusPendingCall *pc, void *aptr)
     dsme_battery_status_set(status);
 
 cleanup:
-
     if( rsp )
         dbus_message_unref(rsp);
 
@@ -1661,7 +1651,6 @@ xmce_battery_level_reply_cb(DBusPendingCall *pc, void *aptr)
     dsme_battery_level_set(level);
 
 cleanup:
-
     if( rsp )
         dbus_message_unref(rsp);
 
@@ -1828,7 +1817,6 @@ systembus_connect(void)
     xmce_tracking_init();
 
 cleanup:
-
     dbus_error_free(&err);
 }
 
@@ -1868,7 +1856,6 @@ send_charger_state(bool charging)
     modules_broadcast_internally(&msg);
 
 cleanup:
-
     return;
 }
 

--- a/modules/batterytracker.c
+++ b/modules/batterytracker.c
@@ -378,7 +378,7 @@ init_done_set(bool reached)
     if( init_done == reached )
         goto EXIT;
 
-    dsme_log(LOG_INFO, PFIX"init_done: %s -> %s",
+    dsme_log(LOG_INFO, PFIX "init_done: %s -> %s",
              bool_repr(init_done),
              bool_repr(reached));
     init_done = reached;
@@ -440,7 +440,7 @@ static void dsme_usb_cable_state_set(dsme_usb_cable_state_t state)
     if( dsme_usb_cable_state == state )
         goto EXIT;
 
-    dsme_log(LOG_INFO, PFIX"dsme_usb_cable_state: %s -> %s",
+    dsme_log(LOG_INFO, PFIX "dsme_usb_cable_state: %s -> %s",
              dsme_usb_cable_state_repr(dsme_usb_cable_state),
              dsme_usb_cable_state_repr(state));
     dsme_usb_cable_state = state;
@@ -485,7 +485,7 @@ static void dsme_charger_state_set(dsme_charger_state_t state)
     if( dsme_charger_state == state )
         goto EXIT;
 
-    dsme_log(LOG_INFO, PFIX"dsme_charger_state: %s -> %s",
+    dsme_log(LOG_INFO, PFIX "dsme_charger_state: %s -> %s",
              dsme_charger_state_repr(dsme_charger_state),
              dsme_charger_state_repr(state));
     dsme_charger_state = state;
@@ -537,7 +537,7 @@ static void dsme_battery_status_set(dsme_battery_status_t status)
     if( dsme_battery_status == status )
         goto EXIT;
 
-    dsme_log(LOG_INFO, PFIX"dsme_battery_status: %s -> %s",
+    dsme_log(LOG_INFO, PFIX "dsme_battery_status: %s -> %s",
              dsme_battery_status_repr(dsme_battery_status),
              dsme_battery_status_repr(status));
     dsme_battery_status = status;
@@ -581,7 +581,7 @@ static void dsme_battery_level_set(dsme_battery_level_t level)
     if( dsme_battery_level == level )
         goto EXIT;
 
-    dsme_log(LOG_INFO, PFIX"dsme_battery_level: %s -> %s",
+    dsme_log(LOG_INFO, PFIX "dsme_battery_level: %s -> %s",
              dsme_battery_level_repr(dsme_battery_level),
              dsme_battery_level_repr(level));
     dsme_battery_level = level;
@@ -608,7 +608,7 @@ dsme_state_set(dsme_state_t state)
     if( dsme_state == state )
         goto EXIT;
 
-    dsme_log(LOG_INFO, PFIX"dsme_state: %s -> %s",
+    dsme_log(LOG_INFO, PFIX "dsme_state: %s -> %s",
              dsme_state_repr(dsme_state),
              dsme_state_repr(state));
 
@@ -632,7 +632,7 @@ alarm_active_set(bool active)
     if( alarm_active == active )
         goto EXIT;
 
-    dsme_log(LOG_INFO, PFIX"alarm_active: %s -> %s",
+    dsme_log(LOG_INFO, PFIX "alarm_active: %s -> %s",
              bool_repr(alarm_active),
              bool_repr(active));
 
@@ -657,7 +657,7 @@ static dsme_timer_t alarm_holdon_id = 0;
 
 static int alarm_holdon_cb(void* unused)
 {
-    dsme_log(LOG_INFO, PFIX"Alarm hold on time is over");
+    dsme_log(LOG_INFO, PFIX "Alarm hold on time is over");
     alarm_holdon_id = 0;
 
     /* Simulate end-of-alarm */
@@ -670,7 +670,7 @@ static void
 alarm_holdon_start(void)
 {
     if( !alarm_holdon_id ) {
-        dsme_log(LOG_INFO, PFIX"Alarm hold on time started");
+        dsme_log(LOG_INFO, PFIX "Alarm hold on time started");
         alarm_holdon_id =
             dsme_create_timer_seconds(ALARM_DELAYED_TIMEOUT,
                                       alarm_holdon_cb, NULL);
@@ -681,7 +681,7 @@ static void
 alarm_holdon_cancel(void)
 {
     if( alarm_holdon_id ) {
-        dsme_log(LOG_INFO, PFIX"Alarm hold on time canceled");
+        dsme_log(LOG_INFO, PFIX "Alarm hold on time canceled");
         dsme_destroy_timer(alarm_holdon_id),
             alarm_holdon_id = 0;
     }
@@ -734,7 +734,7 @@ static void config_load(void)
 
     if( !(input = fopen(BATTERY_LEVEL_CONFIG_FILE, "r")) ) {
         if( errno != ENOENT )
-            dsme_log(LOG_ERR, PFIX"%s: can't read config: %m",
+            dsme_log(LOG_ERR, PFIX "%s: can't read config: %m",
                      BATTERY_LEVEL_CONFIG_FILE);
         goto EXIT;
     }
@@ -749,7 +749,7 @@ static void config_load(void)
         /* Must define at least "min_level" and "polling time".
          */
         if( values < 2 ) {
-            dsme_log(LOG_ERR, PFIX"%s:%zd: %s: not enough data",
+            dsme_log(LOG_ERR, PFIX "%s:%zd: %s: not enough data",
                      BATTERY_LEVEL_CONFIG_FILE, i+1,
                      config_level_name[i]);
             goto EXIT;
@@ -770,7 +770,7 @@ static void config_load(void)
          * Polling times should also make sense  10-1000s
          */
         if( temp[i].polling_time < 10 || temp[i].polling_time > 1000 ) {
-            dsme_log(LOG_ERR, PFIX"%s:%zd: %s: invalid polling_time=%d",
+            dsme_log(LOG_ERR, PFIX "%s:%zd: %s: invalid polling_time=%d",
                      BATTERY_LEVEL_CONFIG_FILE, i+1,
                      config_level_name[i],
                      temp[i].polling_time);
@@ -778,7 +778,7 @@ static void config_load(void)
         }
 
         if( temp[i].min_level < 0 || temp[i].min_level > 100 ) {
-            dsme_log(LOG_ERR, PFIX"%s:%zd: %s: invalid min_level=%d",
+            dsme_log(LOG_ERR, PFIX "%s:%zd: %s: invalid min_level=%d",
                      BATTERY_LEVEL_CONFIG_FILE, i+1,
                      config_level_name[i],
                      temp[i].min_level);
@@ -786,7 +786,7 @@ static void config_load(void)
         }
 
         if( (i > 0) && temp[i-1].min_level <= temp[i].min_level ) {
-            dsme_log(LOG_ERR, PFIX"%s:%zd: %s: min_level=%d is not descending",
+            dsme_log(LOG_ERR, PFIX "%s:%zd: %s: min_level=%d is not descending",
                      BATTERY_LEVEL_CONFIG_FILE, i+1,
                      config_level_name[i],
                      temp[i].min_level);
@@ -802,14 +802,14 @@ EXIT:
 
     if( success ) {
         memcpy(config_level_data, temp, sizeof config_level_data);
-        dsme_log(LOG_INFO, PFIX"Using battery level values from %s",
+        dsme_log(LOG_INFO, PFIX "Using battery level values from %s",
                  BATTERY_LEVEL_CONFIG_FILE);
     }
     else {
-        dsme_log(LOG_DEBUG, PFIX"Using internal battery level values");
+        dsme_log(LOG_DEBUG, PFIX "Using internal battery level values");
     }
 
-    dsme_log(LOG_DEBUG, PFIX"Shutdown limit is < %d%%",
+    dsme_log(LOG_DEBUG, PFIX "Shutdown limit is < %d%%",
              config_level_data[DSME_BATTERY_CONFIG_WARNING].min_level);
 }
 
@@ -889,7 +889,7 @@ static int battery_empty_rethink_cb(void *aptr)
          */
         if( request_shutdown && condition_alarm_is_active() ) {
             request_shutdown = false;
-            dsme_log(LOG_DEBUG, PFIX"Active alarm - do not shutdown");
+            dsme_log(LOG_DEBUG, PFIX "Active alarm - do not shutdown");
         }
 
         /* Before starting shutdown, check charging. If charging is
@@ -899,13 +899,13 @@ static int battery_empty_rethink_cb(void *aptr)
          */
         if( request_shutdown && condition_charging_is_on() ) {
             request_shutdown = false;
-            dsme_log(LOG_DEBUG, PFIX"Charging - do not shutdown");
+            dsme_log(LOG_DEBUG, PFIX "Charging - do not shutdown");
         }
 
         /* If charging in USER state, make sure level won't drop too much, keep min 1% */
         if( !request_shutdown && condition_level_is_critical() ) {
             request_shutdown = true;
-            dsme_log(LOG_INFO, PFIX"Battery level keeps dropping - must shutdown");
+            dsme_log(LOG_INFO, PFIX "Battery level keeps dropping - must shutdown");
         }
 
         /* In any case we must not change direction in the middle
@@ -914,12 +914,12 @@ static int battery_empty_rethink_cb(void *aptr)
          * attempt to bypass act dead mode */
         if( request_shutdown && !init_done ) {
             request_shutdown = false;
-            dsme_log(LOG_DEBUG, PFIX"Mid boot up - must not shutdown");
+            dsme_log(LOG_DEBUG, PFIX "Mid boot up - must not shutdown");
         }
     }
 
     if( shutdown_requested != request_shutdown ) {
-        dsme_log(LOG_CRIT, PFIX"Battery empty shutdown %s",
+        dsme_log(LOG_CRIT, PFIX "Battery empty shutdown %s",
                  request_shutdown ? "requested" : "canceled");
 
         shutdown_requested = request_shutdown;
@@ -965,7 +965,7 @@ static bool xmce_running = false;
 static void
 xmce_running_set(bool running)
 {
-    dsme_log(LOG_DEBUG, PFIX"xmce_running=%d running=%d",
+    dsme_log(LOG_DEBUG, PFIX "xmce_running=%d running=%d",
              xmce_running, running);
 
     if( xmce_running == running )
@@ -973,7 +973,7 @@ xmce_running_set(bool running)
 
     xmce_running = running;
 
-    dsme_log(LOG_DEBUG, PFIX"mce is %s",  xmce_running ? "running" : "stopped");
+    dsme_log(LOG_DEBUG, PFIX "mce is %s",  xmce_running ? "running" : "stopped");
 
     if( xmce_running ) {
         xmce_send_usb_cable_state_query();
@@ -1105,13 +1105,13 @@ xmce_name_owner_filter_cb(DBusConnection *con, DBusMessage *msg, void *aptr)
                                DBUS_TYPE_STRING, &prev,
                                DBUS_TYPE_STRING, &curr,
                                DBUS_TYPE_INVALID) ) {
-        dsme_log(LOG_WARNING, PFIX"name owner signal: %s: %s",
+        dsme_log(LOG_WARNING, PFIX "name owner signal: %s: %s",
                  err.name, err.message);
         goto cleanup;
     }
 
     if( !strcmp(name, MCE_SERVICE) ) {
-        dsme_log(LOG_DEBUG, PFIX"mce name owner: %s", curr);
+        dsme_log(LOG_DEBUG, PFIX "mce name owner: %s", curr);
         xmce_running_set(*curr != 0);
     }
 
@@ -1149,18 +1149,18 @@ xmce_name_owner_reply_cb(DBusPendingCall *pc, void *aptr)
 
     if( dbus_set_error_from_message(&err, rsp) ) {
         if( strcmp(err.name, DBUS_ERROR_NAME_HAS_NO_OWNER) ) {
-            dsme_log(LOG_WARNING, PFIX"mce name owner error reply: %s: %s",
+            dsme_log(LOG_WARNING, PFIX "mce name owner error reply: %s: %s",
                      err.name, err.message);
         }
     }
     else if( !dbus_message_get_args(rsp, &err,
                                DBUS_TYPE_STRING, &dta,
                                DBUS_TYPE_INVALID) ) {
-        dsme_log(LOG_WARNING, PFIX"mce name owner parse error: %s: %s",
+        dsme_log(LOG_WARNING, PFIX "mce name owner parse error: %s: %s",
                  err.name, err.message);
     }
     else {
-        dsme_log(LOG_DEBUG, PFIX"mce name owner reply: %s", dta);
+        dsme_log(LOG_DEBUG, PFIX "mce name owner reply: %s", dta);
     }
 
     xmce_running_set(dta && *dta);
@@ -1180,7 +1180,7 @@ xmce_forget_mce_name_owner_query(void)
     if( !xmce_name_owner_query_pc )
         goto EXIT;
 
-    dsme_log(LOG_DEBUG, PFIX"forget mce name owner query");
+    dsme_log(LOG_DEBUG, PFIX "forget mce name owner query");
     dbus_pending_call_cancel(xmce_name_owner_query_pc);
     dbus_pending_call_unref(xmce_name_owner_query_pc),
         xmce_name_owner_query_pc = 0;
@@ -1196,7 +1196,7 @@ EXIT:
 static void
 xmce_send_name_owner_query(void)
 {
-    dsme_log(LOG_DEBUG, PFIX"mce name owner query");
+    dsme_log(LOG_DEBUG, PFIX "mce name owner query");
 
     bool             res  = false;
     DBusMessage     *req  = 0;
@@ -1235,9 +1235,9 @@ xmce_send_name_owner_query(void)
 
 cleanup:
     if( res )
-        dsme_log(LOG_DEBUG, PFIX"mce name owner query sent");
+        dsme_log(LOG_DEBUG, PFIX "mce name owner query sent");
     else
-        dsme_log(LOG_ERR, PFIX"failed to send mce name owner query");
+        dsme_log(LOG_ERR, PFIX "failed to send mce name owner query");
 
     if( pc )
         dbus_pending_call_unref(pc);
@@ -1275,7 +1275,7 @@ xmce_usb_cable_state_reply_cb(DBusPendingCall *pc, void *aptr)
         goto cleanup;
 
     if( dbus_set_error_from_message(&err, rsp) ) {
-        dsme_log(LOG_ERR, PFIX"cable_state error reply: %s: %s",
+        dsme_log(LOG_ERR, PFIX "cable_state error reply: %s: %s",
                  err.name, err.message);
         goto cleanup;
     }
@@ -1284,12 +1284,12 @@ xmce_usb_cable_state_reply_cb(DBusPendingCall *pc, void *aptr)
                                DBUS_TYPE_STRING, &arg,
                                DBUS_TYPE_INVALID) )
     {
-        dsme_log(LOG_ERR, PFIX"cable_state parse error: %s: %s",
+        dsme_log(LOG_ERR, PFIX "cable_state parse error: %s: %s",
                  err.name, err.message);
         goto cleanup;
     }
 
-    dsme_log(LOG_DEBUG, PFIX"cable_state reply: %s", arg);
+    dsme_log(LOG_DEBUG, PFIX "cable_state reply: %s", arg);
     dsme_usb_cable_state_t state = dsme_usb_cable_state_parse(arg);
     dsme_usb_cable_state_set(state);
 
@@ -1309,7 +1309,7 @@ xmce_forget_usb_cable_state_query(void)
     if( !xmce_usb_cable_state_query_pc )
         goto EXIT;
 
-    dsme_log(LOG_DEBUG, PFIX"forget cable_state query");
+    dsme_log(LOG_DEBUG, PFIX "forget cable_state query");
     dbus_pending_call_cancel(xmce_usb_cable_state_query_pc);
     dbus_pending_call_unref(xmce_usb_cable_state_query_pc),
         xmce_usb_cable_state_query_pc = 0;
@@ -1354,9 +1354,9 @@ xmce_send_usb_cable_state_query(void)
 
 cleanup:
     if( res )
-        dsme_log(LOG_DEBUG, PFIX"cable_state query sent");
+        dsme_log(LOG_DEBUG, PFIX "cable_state query sent");
     else
-        dsme_log(LOG_ERR, PFIX"failed to send cable_state query");
+        dsme_log(LOG_ERR, PFIX "failed to send cable_state query");
 
     if( pc )
         dbus_pending_call_unref(pc);
@@ -1394,7 +1394,7 @@ xmce_charger_state_reply_cb(DBusPendingCall *pc, void *aptr)
         goto cleanup;
 
     if( dbus_set_error_from_message(&err, rsp) ) {
-        dsme_log(LOG_ERR, PFIX"charger_state error reply: %s: %s",
+        dsme_log(LOG_ERR, PFIX "charger_state error reply: %s: %s",
                  err.name, err.message);
         goto cleanup;
     }
@@ -1403,12 +1403,12 @@ xmce_charger_state_reply_cb(DBusPendingCall *pc, void *aptr)
                                DBUS_TYPE_STRING, &arg,
                                DBUS_TYPE_INVALID) )
     {
-        dsme_log(LOG_ERR, PFIX"charger_state parse error: %s: %s",
+        dsme_log(LOG_ERR, PFIX "charger_state parse error: %s: %s",
                  err.name, err.message);
         goto cleanup;
     }
 
-    dsme_log(LOG_DEBUG, PFIX"charger_state reply: %s", arg);
+    dsme_log(LOG_DEBUG, PFIX "charger_state reply: %s", arg);
     dsme_charger_state_t state = dsme_charger_state_parse(arg);
     dsme_charger_state_set(state);
 
@@ -1428,7 +1428,7 @@ xmce_forget_charger_state_query(void)
     if( !xmce_charger_state_query_pc )
         goto EXIT;
 
-    dsme_log(LOG_DEBUG, PFIX"forget charger_state query");
+    dsme_log(LOG_DEBUG, PFIX "forget charger_state query");
     dbus_pending_call_cancel(xmce_charger_state_query_pc);
     dbus_pending_call_unref(xmce_charger_state_query_pc),
         xmce_charger_state_query_pc = 0;
@@ -1473,9 +1473,9 @@ xmce_send_charger_state_query(void)
 
 cleanup:
     if( res )
-        dsme_log(LOG_DEBUG, PFIX"charger_state query sent");
+        dsme_log(LOG_DEBUG, PFIX "charger_state query sent");
     else
-        dsme_log(LOG_ERR, PFIX"failed to send charger_state query");
+        dsme_log(LOG_ERR, PFIX "failed to send charger_state query");
 
     if( pc )
         dbus_pending_call_unref(pc);
@@ -1513,7 +1513,7 @@ xmce_battery_status_reply_cb(DBusPendingCall *pc, void *aptr)
         goto cleanup;
 
     if( dbus_set_error_from_message(&err, rsp) ) {
-        dsme_log(LOG_ERR, PFIX"battery_status error reply: %s: %s",
+        dsme_log(LOG_ERR, PFIX "battery_status error reply: %s: %s",
                  err.name, err.message);
         goto cleanup;
     }
@@ -1522,12 +1522,12 @@ xmce_battery_status_reply_cb(DBusPendingCall *pc, void *aptr)
                                DBUS_TYPE_STRING, &arg,
                                DBUS_TYPE_INVALID) )
     {
-        dsme_log(LOG_ERR, PFIX"battery_status parse error: %s: %s",
+        dsme_log(LOG_ERR, PFIX "battery_status parse error: %s: %s",
                  err.name, err.message);
         goto cleanup;
     }
 
-    dsme_log(LOG_DEBUG, PFIX"battery_status reply: %s", arg);
+    dsme_log(LOG_DEBUG, PFIX "battery_status reply: %s", arg);
     dsme_battery_status_t status = dsme_battery_status_parse(arg);
     dsme_battery_status_set(status);
 
@@ -1547,7 +1547,7 @@ xmce_forget_battery_status_query(void)
     if( !xmce_battery_status_query_pc )
         goto EXIT;
 
-    dsme_log(LOG_DEBUG, PFIX"forget battery_status query");
+    dsme_log(LOG_DEBUG, PFIX "forget battery_status query");
     dbus_pending_call_cancel(xmce_battery_status_query_pc);
     dbus_pending_call_unref(xmce_battery_status_query_pc),
         xmce_battery_status_query_pc = 0;
@@ -1592,9 +1592,9 @@ xmce_send_battery_status_query(void)
 
 cleanup:
     if( res )
-        dsme_log(LOG_DEBUG, PFIX"battery_status query sent");
+        dsme_log(LOG_DEBUG, PFIX "battery_status query sent");
     else
-        dsme_log(LOG_ERR, PFIX"failed to send battery_status query");
+        dsme_log(LOG_ERR, PFIX "failed to send battery_status query");
 
     if( pc )
         dbus_pending_call_unref(pc);
@@ -1632,7 +1632,7 @@ xmce_battery_level_reply_cb(DBusPendingCall *pc, void *aptr)
         goto cleanup;
 
     if( dbus_set_error_from_message(&err, rsp) ) {
-        dsme_log(LOG_ERR, PFIX"battery_level error reply: %s: %s",
+        dsme_log(LOG_ERR, PFIX "battery_level error reply: %s: %s",
                  err.name, err.message);
         goto cleanup;
     }
@@ -1641,12 +1641,12 @@ xmce_battery_level_reply_cb(DBusPendingCall *pc, void *aptr)
                                DBUS_TYPE_INT32, &arg,
                                DBUS_TYPE_INVALID) )
     {
-        dsme_log(LOG_ERR, PFIX"battery_level parse error: %s: %s",
+        dsme_log(LOG_ERR, PFIX "battery_level parse error: %s: %s",
                  err.name, err.message);
         goto cleanup;
     }
 
-    dsme_log(LOG_DEBUG, PFIX"battery_level reply: %d", (int)arg);
+    dsme_log(LOG_DEBUG, PFIX "battery_level reply: %d", (int)arg);
     dsme_battery_level_t level = arg;
     dsme_battery_level_set(level);
 
@@ -1666,7 +1666,7 @@ xmce_forget_battery_level_query(void)
     if( !xmce_battery_level_query_pc )
         goto EXIT;
 
-    dsme_log(LOG_DEBUG, PFIX"forget battery_level query");
+    dsme_log(LOG_DEBUG, PFIX "forget battery_level query");
     dbus_pending_call_cancel(xmce_battery_level_query_pc);
     dbus_pending_call_unref(xmce_battery_level_query_pc),
         xmce_battery_level_query_pc = 0;
@@ -1711,9 +1711,9 @@ xmce_send_battery_level_query(void)
 
 cleanup:
     if( res )
-        dsme_log(LOG_DEBUG, PFIX"battery_level query sent");
+        dsme_log(LOG_DEBUG, PFIX "battery_level query sent");
     else
-        dsme_log(LOG_ERR, PFIX"failed to send battery_level query");
+        dsme_log(LOG_ERR, PFIX "failed to send battery_level query");
 
     if( pc )
         dbus_pending_call_unref(pc);
@@ -1732,7 +1732,7 @@ xmce_usb_cable_state_signal_cb(const DsmeDbusMessage* ind)
 {
     const char *arg = dsme_dbus_message_get_string(ind);
 
-    dsme_log(LOG_DEBUG, PFIX"dbus signal: %s(%s)",
+    dsme_log(LOG_DEBUG, PFIX "dbus signal: %s(%s)",
              MCE_USB_CABLE_STATE_SIG, arg);
 
     dsme_usb_cable_state_t state = dsme_usb_cable_state_parse(arg);
@@ -1746,7 +1746,7 @@ xmce_charger_state_signal_cb(const DsmeDbusMessage* ind)
 {
     const char *arg = dsme_dbus_message_get_string(ind);
 
-    dsme_log(LOG_DEBUG, PFIX"dbus signal: %s(%s)",
+    dsme_log(LOG_DEBUG, PFIX "dbus signal: %s(%s)",
              MCE_CHARGER_STATE_SIG, arg);
 
     dsme_charger_state_t state = dsme_charger_state_parse(arg);
@@ -1760,7 +1760,7 @@ xmce_battery_status_signal_cb(const DsmeDbusMessage* ind)
 {
     const char *arg = dsme_dbus_message_get_string(ind);
 
-    dsme_log(LOG_DEBUG, PFIX"dbus signal: %s(%s)",
+    dsme_log(LOG_DEBUG, PFIX "dbus signal: %s(%s)",
              MCE_BATTERY_STATUS_SIG, arg);
 
     dsme_battery_status_t status = dsme_battery_status_parse(arg);
@@ -1774,7 +1774,7 @@ xmce_battery_level_signal_cb(const DsmeDbusMessage* ind)
 {
     int arg = dsme_dbus_message_get_int(ind);
 
-    dsme_log(LOG_DEBUG, PFIX"dbus signal: %s(%d)",
+    dsme_log(LOG_DEBUG, PFIX "dbus signal: %s(%d)",
              MCE_BATTERY_STATUS_SIG, arg);
 
     dsme_battery_level_t level = arg;
@@ -1809,7 +1809,7 @@ systembus_connect(void)
     DBusError err = DBUS_ERROR_INIT;
 
     if( !(systembus = dsme_dbus_get_connection(&err)) ) {
-        dsme_log(LOG_WARNING, PFIX"can't connect to systembus: %s: %s",
+        dsme_log(LOG_WARNING, PFIX "can't connect to systembus: %s: %s",
                  err.name, err.message);
         goto cleanup;
     }
@@ -1849,7 +1849,7 @@ send_charger_state(bool charging)
     if( prev == charging )
         goto cleanup;
 
-    dsme_log(LOG_DEBUG, PFIX"broadcast: charger_state=%s", bool_repr(charging));
+    dsme_log(LOG_DEBUG, PFIX "broadcast: charger_state=%s", bool_repr(charging));
 
     DSM_MSGTYPE_SET_CHARGER_STATE msg = DSME_MSG_INIT(DSM_MSGTYPE_SET_CHARGER_STATE);
     prev = msg.connected = charging;
@@ -1862,7 +1862,7 @@ cleanup:
 static void
 send_battery_state(bool empty)
 {
-    dsme_log(LOG_DEBUG, PFIX"broadcast: battery_state=%s",
+    dsme_log(LOG_DEBUG, PFIX "broadcast: battery_state=%s",
              empty ? "empty" : "not-empty");
 
     DSM_MSGTYPE_SET_BATTERY_STATE msg =
@@ -1874,7 +1874,7 @@ send_battery_state(bool empty)
 static void
 send_battery_level(dsme_battery_level_t level)
 {
-    dsme_log(LOG_DEBUG, PFIX"broadcast: battery_level=%s",
+    dsme_log(LOG_DEBUG, PFIX "broadcast: battery_level=%s",
              dsme_battery_level_repr(level));
 
     DSM_MSGTYPE_SET_BATTERY_LEVEL msg =
@@ -1886,7 +1886,7 @@ send_battery_level(dsme_battery_level_t level)
 static void
 send_dsme_state_query(void)
 {
-    dsme_log(LOG_DEBUG, PFIX"query: dsme_state");
+    dsme_log(LOG_DEBUG, PFIX "query: dsme_state");
 
     DSM_MSGTYPE_STATE_QUERY query = DSME_MSG_INIT(DSM_MSGTYPE_STATE_QUERY);
     modules_broadcast_internally(&query);
@@ -1898,27 +1898,27 @@ send_dsme_state_query(void)
 
 DSME_HANDLER(DSM_MSGTYPE_DBUS_CONNECTED, client, msg)
 {
-    dsme_log(LOG_DEBUG, PFIX"DBUS_CONNECTED");
+    dsme_log(LOG_DEBUG, PFIX "DBUS_CONNECTED");
     dsme_dbus_bind_signals(&dbus_signals_bound, dbus_signals_array);
     systembus_connect();
 }
 
 DSME_HANDLER(DSM_MSGTYPE_DBUS_DISCONNECT, client, msg)
 {
-    dsme_log(LOG_DEBUG, PFIX"DBUS_DISCONNECT");
+    dsme_log(LOG_DEBUG, PFIX "DBUS_DISCONNECT");
     systembus_disconnect();
 }
 
 DSME_HANDLER(DSM_MSGTYPE_STATE_CHANGE_IND, server, msg)
 {
-    dsme_log(LOG_DEBUG, PFIX"STATE_CHANGE_IND %s",
+    dsme_log(LOG_DEBUG, PFIX "STATE_CHANGE_IND %s",
              dsme_state_repr(msg->state));
     dsme_state_set(msg->state);
 }
 
 DSME_HANDLER(DSM_MSGTYPE_SET_ALARM_STATE, conn, msg)
 {
-    dsme_log(LOG_DEBUG, PFIX"SET_ALARM_STATE %s",
+    dsme_log(LOG_DEBUG, PFIX "SET_ALARM_STATE %s",
              bool_repr(msg->alarm_set));
     alarm_active_set(msg->alarm_set);
 }
@@ -1940,7 +1940,7 @@ module_fn_info_t message_handlers[] =
 void
 module_init(module_t *handle)
 {
-    dsme_log(LOG_DEBUG, PFIX"loading");
+    dsme_log(LOG_DEBUG, PFIX "loading");
 
     /* Cache module handle */
     this_module = handle;
@@ -1958,7 +1958,7 @@ module_init(module_t *handle)
 void
 module_fini(void)
 {
-    dsme_log(LOG_DEBUG, PFIX"unloading");
+    dsme_log(LOG_DEBUG, PFIX "unloading");
 
     /* Make sure D-Bus signal handlers get unregistered */
     dsme_dbus_unbind_signals(&dbus_signals_bound, dbus_signals_array);

--- a/modules/bootreasonlogger.c
+++ b/modules/bootreasonlogger.c
@@ -132,7 +132,7 @@ static const char * get_timestamp(void)
             timestamp = date_time;
     }
     else
-        dsme_log(LOG_ERR, PFIX"failed to get timestamp");
+        dsme_log(LOG_ERR, PFIX "failed to get timestamp");
 
     return timestamp;
 }
@@ -152,7 +152,7 @@ static void write_log(const char *state, const char *reason)
     }
 
     if (! success) {
-        dsme_log(LOG_ERR, PFIX"can't write into %s", BOOT_LOG_FILE);
+        dsme_log(LOG_ERR, PFIX "can't write into %s", BOOT_LOG_FILE);
     }
 }
 
@@ -164,13 +164,13 @@ static int get_cmd_line_value(char* get_value, int max_len, const char* key)
     FILE *file = 0;
 
     if( !(file = fopen(path, "r")) ) {
-        dsme_log(LOG_ERR, PFIX"Could not open %s: %m", path);
+        dsme_log(LOG_ERR, PFIX "Could not open %s: %m", path);
         goto EXIT;
     }
 
     char cmdline[MAX_CMDLINE_LEN];
     if( !fgets(cmdline, sizeof cmdline, file) ) {
-        dsme_log(LOG_ERR, PFIX"Could not read %s: %m", path);
+        dsme_log(LOG_ERR, PFIX "Could not read %s: %m", path);
         goto EXIT;
     }
 
@@ -245,8 +245,7 @@ static void log_shutdown(void)
 
 DSME_HANDLER(DSM_MSGTYPE_SET_BATTERY_STATE, conn, battery)
 {
-    dsme_log(LOG_DEBUG,
-             PFIX"battery %s state received",
+    dsme_log(LOG_DEBUG, PFIX "battery %s state received",
              battery->empty ? "empty" : "not empty");
 
     write_log("Received: battery ", battery->empty ? "empty" : "not empty");
@@ -271,8 +270,7 @@ DSME_HANDLER(DSM_MSGTYPE_SET_THERMAL_STATUS, conn, msg)
     else
         temp_status = "normal";
 
-    dsme_log(LOG_DEBUG,
-             PFIX"temp (%s) state: %s (%dC)", msg->sensor_name, temp_status, msg->temperature);
+    dsme_log(LOG_DEBUG, PFIX "temp (%s) state: %s (%dC)", msg->sensor_name, temp_status, msg->temperature);
     snprintf(str, sizeof(str), "device (%s) temp status %s (%dC)", msg->sensor_name, temp_status, msg->temperature);
     write_log("Received:", str);
     if (overheated)
@@ -331,7 +329,7 @@ module_fn_info_t message_handlers[] = {
 
 void module_init(module_t* handle)
 {
-    dsme_log(LOG_DEBUG, "bootreasonlogger.so loaded");
+    dsme_log(LOG_DEBUG, PFIX "bootreasonlogger.so loaded");
     log_startup();
     saved_shutdown_reason = SD_REASON_UNKNOWN;
 }
@@ -339,5 +337,5 @@ void module_init(module_t* handle)
 void module_fini(void)
 {
     log_shutdown();
-    dsme_log(LOG_DEBUG, "bootreasonlogger.so unloaded");
+    dsme_log(LOG_DEBUG, PFIX "bootreasonlogger.so unloaded");
 }

--- a/modules/dbusautoconnector.c
+++ b/modules/dbusautoconnector.c
@@ -39,7 +39,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#define ME "dbusautoconnector: "
+#define PFIX "dbusautoconnector: "
 
 #define DSME_SYSTEM_BUS_DIR   "/var/run/dbus"
 #define DSME_SYSTEM_BUS_FILE  "system_bus_socket"
@@ -113,7 +113,7 @@ connect_request(void)
 static int
 connect_timer_cb(void* dummy)
 {
-    dsme_log(LOG_DEBUG, ME"Connect timer: triggered");
+    dsme_log(LOG_DEBUG, PFIX "Connect timer: triggered");
 
     connect_request();
 
@@ -127,7 +127,7 @@ connect_timer_start(void)
     if( connect_timer_id )
         goto EXIT;
 
-    dsme_log(LOG_DEBUG, ME"Connect timer: start");
+    dsme_log(LOG_DEBUG, PFIX "Connect timer: start");
 
     connect_timer_id = dsme_create_timer_seconds(1, connect_timer_cb, 0);
 
@@ -141,7 +141,7 @@ static void
 connect_timer_stop(void)
 {
     if( connect_timer_id ) {
-        dsme_log(LOG_DEBUG, ME"Connect timer: stop");
+        dsme_log(LOG_DEBUG, PFIX "Connect timer: stop");
 
         dsme_destroy_timer(connect_timer_id), connect_timer_id = 0;
     }
@@ -164,7 +164,7 @@ systembus_state_update(void)
     if( prev == systembus_state )
         goto EXIT;
 
-    dsme_log(LOG_DEBUG, ME"SystemBus socket exists: %d -> %d",
+    dsme_log(LOG_DEBUG, PFIX "SystemBus socket exists: %d -> %d",
              prev, systembus_state);
 
     if( systembus_state == BUS_STATE_PRESENT )
@@ -195,7 +195,7 @@ systembus_watcher_cb(GIOChannel *src, GIOCondition cnd, gpointer dta)
     char buf[4096] __attribute__ ((aligned(__alignof__(struct inotify_event))));
 
     if( cnd & (G_IO_ERR | G_IO_HUP | G_IO_NVAL) ) {
-        dsme_log(LOG_ERR, ME"SystemBus watch: ERR, HUP or NVAL condition");
+        dsme_log(LOG_ERR, PFIX "SystemBus watch: ERR, HUP or NVAL condition");
         goto EXIT;
     }
 
@@ -206,7 +206,7 @@ systembus_watcher_cb(GIOChannel *src, GIOCondition cnd, gpointer dta)
             if( errno == EAGAIN || errno == EINTR )
                 keep_watching = true;
             else
-                dsme_log(LOG_ERR, ME"SystemBus watch: read error: %m");
+                dsme_log(LOG_ERR, PFIX "SystemBus watch: read error: %m");
             goto EXIT;
         }
 
@@ -214,14 +214,14 @@ systembus_watcher_cb(GIOChannel *src, GIOCondition cnd, gpointer dta)
 
         while( todo > 0 ) {
             if( todo < sizeof *eve ) {
-                dsme_log(LOG_ERR, ME"SystemBus watch: truncated event");
+                dsme_log(LOG_ERR, PFIX "SystemBus watch: truncated event");
                 goto EXIT;
             }
 
             int size = sizeof *eve + eve->len;
 
             if( todo < size ) {
-                dsme_log(LOG_ERR, ME"SystemBus watch: oversized event");
+                dsme_log(LOG_ERR, PFIX "SystemBus watch: oversized event");
                 goto EXIT;
             }
 
@@ -255,10 +255,10 @@ systembus_watcher_start(void)
     if( systembus_watcher_id )
         goto cleanup;
 
-    dsme_log(LOG_DEBUG, ME"SystemBus watch: starting");
+    dsme_log(LOG_DEBUG, PFIX "SystemBus watch: starting");
 
     if( (systembus_watcher_fd = inotify_init()) == -1 ) {
-        dsme_log(LOG_ERR, ME"SystemBus watch: inotify init: %m");
+        dsme_log(LOG_ERR, PFIX "SystemBus watch: inotify init: %m");
         goto cleanup;
     }
 
@@ -268,12 +268,12 @@ systembus_watcher_start(void)
                                              DSME_SYSTEM_BUS_DIR, mask);
 
     if( systembus_watcher_wd == -1 ) {
-        dsme_log(LOG_ERR, ME"SystemBus watch: add inotify watch: %m");
+        dsme_log(LOG_ERR, PFIX "SystemBus watch: add inotify watch: %m");
         goto cleanup;
     }
 
     if( !(chn = g_io_channel_unix_new(systembus_watcher_fd)) ) {
-        dsme_log(LOG_ERR, ME"SystemBus watch: creating io channel failed");
+        dsme_log(LOG_ERR, PFIX "SystemBus watch: creating io channel failed");
         goto cleanup;
     }
 
@@ -281,7 +281,7 @@ systembus_watcher_start(void)
                                           G_IO_IN | G_IO_ERR | G_IO_HUP | G_IO_NVAL,
                                           systembus_watcher_cb, 0);
     if( !systembus_watcher_id )
-        dsme_log(LOG_ERR, ME"SystemBus watch: adding io watch failed");
+        dsme_log(LOG_ERR, PFIX "SystemBus watch: adding io watch failed");
 
 cleanup:
     if( !systembus_watcher_id )
@@ -294,7 +294,7 @@ static void
 systembus_watcher_stop(void)
 {
     if( systembus_watcher_id ) {
-        dsme_log(LOG_DEBUG, ME"SystemBus watch: stopping");
+        dsme_log(LOG_DEBUG, PFIX "SystemBus watch: stopping");
         g_source_remove(systembus_watcher_id), systembus_watcher_id = 0;
     }
 
@@ -314,13 +314,13 @@ systembus_watcher_stop(void)
 
 DSME_HANDLER(DSM_MSGTYPE_DBUS_CONNECTED, client, msg)
 {
-    dsme_log(LOG_DEBUG, ME"DBUS_CONNECTED");
+    dsme_log(LOG_DEBUG, PFIX "DBUS_CONNECTED");
     connect_timer_stop();
 }
 
 DSME_HANDLER(DSM_MSGTYPE_DBUS_DISCONNECT, client, msg)
 {
-    dsme_log(LOG_DEBUG, ME"DBUS_DISCONNECT");
+    dsme_log(LOG_DEBUG, PFIX "DBUS_DISCONNECT");
     connect_timer_stop();
 }
 
@@ -332,7 +332,7 @@ module_fn_info_t message_handlers[] = {
 
 void module_init(module_t* handle)
 {
-    dsme_log(LOG_DEBUG, ME"loaded");
+    dsme_log(LOG_DEBUG, PFIX "loaded");
 
     this_module = handle;
 
@@ -346,5 +346,5 @@ void module_fini(void)
 
     connect_timer_stop();
 
-    dsme_log(LOG_DEBUG, ME"unloaded");
+    dsme_log(LOG_DEBUG, PFIX "unloaded");
 }

--- a/modules/dbusautoconnector.c
+++ b/modules/dbusautoconnector.c
@@ -284,7 +284,6 @@ systembus_watcher_start(void)
         dsme_log(LOG_ERR, ME"SystemBus watch: adding io watch failed");
 
 cleanup:
-
     if( !systembus_watcher_id )
         systembus_watcher_stop();
 

--- a/modules/dbusproxy.c
+++ b/modules/dbusproxy.c
@@ -100,8 +100,7 @@ static void get_state(const DsmeDbusMessage* request, DsmeDbusMessage** reply)
 static void req_powerup(const DsmeDbusMessage* request, DsmeDbusMessage** reply)
 {
   char* sender = dsme_dbus_endpoint_name(request);
-  dsme_log(LOG_NOTICE,
-           "powerup request received over D-Bus from %s",
+  dsme_log(LOG_NOTICE, PFIX "powerup request received over D-Bus from %s",
            sender ? sender : "(unknown)");
   free(sender);
 
@@ -113,8 +112,7 @@ static void req_powerup(const DsmeDbusMessage* request, DsmeDbusMessage** reply)
 static void req_reboot(const DsmeDbusMessage* request, DsmeDbusMessage** reply)
 {
   char* sender = dsme_dbus_endpoint_name(request);
-  dsme_log(LOG_NOTICE,
-           "reboot request received over D-Bus from %s",
+  dsme_log(LOG_NOTICE, PFIX "reboot request received over D-Bus from %s",
            sender ? sender : "(unknown)");
   free(sender);
 
@@ -127,8 +125,7 @@ static void req_shutdown(const DsmeDbusMessage* request,
                          DsmeDbusMessage**      reply)
 {
   char* sender = dsme_dbus_endpoint_name(request);
-  dsme_log(LOG_NOTICE,
-           "shutdown request received over D-Bus from %s",
+  dsme_log(LOG_NOTICE, PFIX "shutdown request received over D-Bus from %s",
            sender ? sender : "(unknown)");
   free(sender);
 
@@ -376,8 +373,7 @@ DSME_HANDLER(DSM_MSGTYPE_STATE_REQ_DENIED_IND, server, msg)
 {
     const char* denied_request = shutdown_action_name(msg->state);
 
-    dsme_log(LOG_WARNING,
-             "proxying %s request denial due to %s to D-Bus",
+    dsme_log(LOG_WARNING, PFIX "proxying %s request denial due to %s to D-Bus",
              denied_request,
              (const char*)DSMEMSG_EXTRA(msg));
 
@@ -392,14 +388,14 @@ DSME_HANDLER(DSM_MSGTYPE_STATE_REQ_DENIED_IND, server, msg)
 
 DSME_HANDLER(DSM_MSGTYPE_DBUS_CONNECT, client, msg)
 {
-    dsme_log(LOG_DEBUG, "dbusproxy: DBUS_CONNECT");
+    dsme_log(LOG_DEBUG, PFIX "DBUS_CONNECT");
 
     dsme_dbus_connect();
 }
 
 DSME_HANDLER(DSM_MSGTYPE_DBUS_CONNECTED, client, msg)
 {
-    dsme_log(LOG_DEBUG, "dbusproxy: DBUS_CONNECTED");
+    dsme_log(LOG_DEBUG, PFIX "DBUS_CONNECTED");
 
     dsme_dbus_bind_methods(&dbus_broadcast_bound,
                            dsme_service,
@@ -419,7 +415,7 @@ DSME_HANDLER(DSM_MSGTYPE_DBUS_CONNECTED, client, msg)
 
 DSME_HANDLER(DSM_MSGTYPE_DBUS_DISCONNECT, client, msg)
 {
-  dsme_log(LOG_DEBUG, "dbusproxy: DBUS_DISCONNECT");
+  dsme_log(LOG_DEBUG, PFIX "DBUS_DISCONNECT");
   dsme_dbus_disconnect();
   dbus_connected = false;
 }
@@ -466,7 +462,7 @@ void module_init(module_t* handle)
    * Instead, wait for DSM_MSGTYPE_DBUS_CONNECTED.
    */
 
-  dsme_log(LOG_DEBUG, "dbusproxy.so loaded");
+  dsme_log(LOG_DEBUG, PFIX "dbusproxy.so loaded");
 }
 
 void module_fini(void)
@@ -490,5 +486,5 @@ void module_fini(void)
     g_free(dsme_version);
     dsme_version = 0;
 
-    dsme_log(LOG_DEBUG, "dbusproxy.so unloaded");
+    dsme_log(LOG_DEBUG, PFIX "dbusproxy.so unloaded");
 }

--- a/modules/diskmonitor.c
+++ b/modules/diskmonitor.c
@@ -555,7 +555,6 @@ diskmon_add_mountpoint(const char *mntpoint, int percent_free, int mb_free)
     diskuse_t *limit = 0;
 
     if( !(limit = diskmon_get_mountpoint(mntpoint)) ) {
-
         limit = diskuse_create(mntpoint);
         diskmon_limit_list = g_slist_prepend(diskmon_limit_list, limit);
     }

--- a/modules/diskmonitor.c
+++ b/modules/diskmonitor.c
@@ -32,7 +32,7 @@
 // to request a disk space check:
 // dbus-send --system --print-reply --dest=com.nokia.diskmonitor /com/nokia/diskmonitor/request com.nokia.diskmonitor.request.req_check
 
-#define LOGPFIX "diskmonitor: "
+#define PFIX "diskmonitor: "
 
 #include <iphbd/iphb_internal.h>
 
@@ -317,7 +317,7 @@ get_boottime(void)
 {
     struct timespec ts = { 0, 0 };
     if( clock_gettime(CLOCK_BOOTTIME, &ts) == -1 ) {
-        dsme_log(LOG_ERR, LOGPFIX"CLOCK_BOOTTIME: %m");
+        dsme_log(LOG_ERR, PFIX "CLOCK_BOOTTIME: %m");
     }
     return ts.tv_sec;
 }
@@ -393,7 +393,7 @@ diskuse_set_limit(diskuse_t *self, int percent_free, int mb_free)
     memset(&stfs, 0, sizeof stfs);
 
     if( statfs(self->mntpoint, &stfs) == -1 ) {
-        dsme_log(LOG_WARNING, LOGPFIX"%s: statfs failed: %m", self->mntpoint);
+        dsme_log(LOG_WARNING, PFIX "%s: statfs failed: %m", self->mntpoint);
         goto EXIT;
     }
 
@@ -424,7 +424,7 @@ diskuse_set_limit(diskuse_t *self, int percent_free, int mb_free)
 EXIT:
     self->mb_limit = (int)mb_lim;
 
-    dsme_log(LOG_DEBUG, "%s: limit=%dMB", self->mntpoint, self->mb_limit);
+    dsme_log(LOG_DEBUG, PFIX "%s: limit=%dMB", self->mntpoint, self->mb_limit);
 }
 
 /** Get current logical disk use state
@@ -450,7 +450,7 @@ diskuse_update_state(diskuse_t *self)
     memset(&stfs, 0, sizeof stfs);
 
     if( statfs(self->mntpoint, &stfs) == -1 ) {
-        dsme_log(LOG_WARNING, LOGPFIX"%s: statfs failed: %m", self->mntpoint);
+        dsme_log(LOG_WARNING, PFIX "%s: statfs failed: %m", self->mntpoint);
         goto EXIT;
     }
 
@@ -471,7 +471,7 @@ EXIT:
     else
         self->state = DISKSPACE_STATE_NORMAL;
 
-    dsme_log(LOG_DEBUG, "%s: avail=%dMB state=%s", self->mntpoint,
+    dsme_log(LOG_DEBUG, PFIX "%s: avail=%dMB state=%s", self->mntpoint,
              self->mb_avail, diskspace_state_repr(self->state));
 
     return self->state;
@@ -487,7 +487,7 @@ diskuse_evaluate(diskuse_t *self, unsigned check_tag)
 
     self->check_tag = check_tag;
 
-    dsme_log(LOG_DEBUG, LOGPFIX"check mountpoint: %s", self->mntpoint);
+    dsme_log(LOG_DEBUG, PFIX "check mountpoint: %s", self->mntpoint);
 
     diskspace_state_t prev = diskuse_get_state(self);
     diskspace_state_t curr = diskuse_update_state(self);
@@ -504,7 +504,7 @@ diskuse_evaluate(diskuse_t *self, unsigned check_tag)
     }
     else
     {
-      dsme_log(LOG_WARNING, "%s: avail=%dMB limit=%dmb state=%s->%s",
+      dsme_log(LOG_WARNING, PFIX "%s: avail=%dMB limit=%dmb state=%s->%s",
                self->mntpoint,
                self->mb_avail,
                self->mb_limit,
@@ -591,7 +591,7 @@ diskmon_load_config(void)
 
     if( !(input = fopen(diskmon_config, "r")) ) {
         if( errno != ENOENT )
-            dsme_log(LOG_ERR, "%s: open failed: %m", diskmon_config);
+            dsme_log(LOG_ERR, PFIX "%s: open failed: %m", diskmon_config);
         goto EXIT;
     }
 
@@ -679,7 +679,7 @@ diskmon_schedule_wakeup(void)
 
     /* Never reschedule wakeups to happen at later time */
     if( next_check_time > curtime && next_check_time < timeout ) {
-        dsme_log(LOG_DEBUG, LOGPFIX"skipping wakeup re-schedule");
+        dsme_log(LOG_DEBUG, PFIX "skipping wakeup re-schedule");
         goto EXIT;
     }
 
@@ -691,7 +691,7 @@ diskmon_schedule_wakeup(void)
     msg.req.pid     = 0;
     msg.data        = 0;
 
-    dsme_log(LOG_DEBUG, LOGPFIX"schedule next wakeup in: %d ... %d seconds",
+    dsme_log(LOG_DEBUG, PFIX "schedule next wakeup in: %d ... %d seconds",
              msg.req.mintime, msg.req.maxtime);
 
     modules_broadcast_internally(&msg);
@@ -712,7 +712,7 @@ diskmon_check_disk_usage(void)
     if( !init_done_received )
         goto EXIT;
 
-    dsme_log(LOG_DEBUG, LOGPFIX"check disk space usage");
+    dsme_log(LOG_DEBUG, PFIX "check disk space usage");
     last_check_time = get_boottime();
 
     if( !(fh = setmntent(_PATH_MOUNTED, "r")) )
@@ -751,8 +751,7 @@ static void handle_check_req_cb(const DsmeDbusMessage* request, DsmeDbusMessage*
         diskmon_schedule_wakeup();
     }
     else {
-        dsme_log(LOG_DEBUG,
-                 LOGPFIX"only %d seconds from the last disk space check request, skip this request",
+        dsme_log(LOG_DEBUG, PFIX "only %d seconds from the last disk space check request, skip this request",
                  (int)seconds_from_last_check);
     }
 
@@ -763,7 +762,7 @@ static void handle_check_req_cb(const DsmeDbusMessage* request, DsmeDbusMessage*
  */
 static void handle_init_done_sig_cb(const DsmeDbusMessage* ind)
 {
-    dsme_log(LOG_DEBUG, LOGPFIX"init_done received");
+    dsme_log(LOG_DEBUG, PFIX "init_done received");
 
     init_done_received = true;
     diskmon_schedule_wakeup();
@@ -776,7 +775,7 @@ static void handle_inactivity_sig_cb(const DsmeDbusMessage* sig)
     const bool inactive                 = dsme_dbus_message_get_bool(sig);
     const bool new_device_active_state  = !inactive;
 
-    dsme_log(LOG_DEBUG, LOGPFIX"device %s signal received",
+    dsme_log(LOG_DEBUG, PFIX "device %s signal received",
              new_device_active_state ? "active" : "inactive");
 
     if( new_device_active_state == device_active ) {
@@ -792,7 +791,7 @@ static void handle_inactivity_sig_cb(const DsmeDbusMessage* sig)
         /* If the last check has not been done recently enough,
          * check immediately on activation. */
         if( seconds_from_last_check >= INTERVAL_WHEN_ACTIVATED ) {
-            dsme_log(LOG_DEBUG, LOGPFIX"%d seconds from the last check",
+            dsme_log(LOG_DEBUG, PFIX "%d seconds from the last check",
                      seconds_from_last_check);
             diskmon_check_disk_usage();
         }
@@ -814,7 +813,7 @@ static void handle_inactivity_sig_cb(const DsmeDbusMessage* sig)
  */
 DSME_HANDLER(DSM_MSGTYPE_WAKEUP, client, msg)
 {
-    dsme_log(LOG_DEBUG, LOGPFIX"iphb timer wakeup");
+    dsme_log(LOG_DEBUG, PFIX "iphb timer wakeup");
 
     /* Clear expecting-wakeup-at timestamp */
     next_check_time = 0;
@@ -828,7 +827,7 @@ DSME_HANDLER(DSM_MSGTYPE_WAKEUP, client, msg)
  */
 DSME_HANDLER(DSM_MSGTYPE_DBUS_CONNECTED, client, msg)
 {
-    dsme_log(LOG_DEBUG, LOGPFIX"DBUS_CONNECTED");
+    dsme_log(LOG_DEBUG, PFIX "DBUS_CONNECTED");
 
     dsme_dbus_bind_methods(&dbus_broadcast_bound,
                            diskmonitor_service,
@@ -847,7 +846,7 @@ DSME_HANDLER(DSM_MSGTYPE_DBUS_CONNECTED, client, msg)
     /* If dsme was restarted after bootup is finished, init-done signal
      * is not going to come again -> check flag file for initial state */
     if( access("/run/systemd/boot-status/init-done", F_OK) == 0 ) {
-        dsme_log(LOG_DEBUG, LOGPFIX"init_done already passed");
+        dsme_log(LOG_DEBUG, PFIX "init_done already passed");
         init_done_received = true;
         diskmon_schedule_wakeup();
     }
@@ -857,7 +856,7 @@ DSME_HANDLER(DSM_MSGTYPE_DBUS_CONNECTED, client, msg)
  */
 DSME_HANDLER(DSM_MSGTYPE_DBUS_DISCONNECT, client, msg)
 {
-    dsme_log(LOG_DEBUG, LOGPFIX"DBUS_DISCONNECT");
+    dsme_log(LOG_DEBUG, PFIX "DBUS_DISCONNECT");
 }
 
 /** Callback for handling logical disk use state change events
@@ -866,7 +865,7 @@ DSME_HANDLER(DSM_MSGTYPE_DISK_SPACE, conn, msg)
 {
     const char* mount_path = DSMEMSG_EXTRA(msg);
 
-    dsme_log(LOG_DEBUG, LOGPFIX"send %s disk space notification for: %s",
+    dsme_log(LOG_DEBUG, PFIX "send %s disk space notification for: %s",
              diskspace_state_repr(msg->diskspace_state), mount_path);
 
     DsmeDbusMessage* sig =
@@ -900,7 +899,7 @@ module_fn_info_t message_handlers[] =
 void
 module_init(module_t* module)
 {
-    dsme_log(LOG_DEBUG, "diskmonitor.so loaded");
+    dsme_log(LOG_DEBUG, PFIX "diskmonitor.so loaded");
 
     if( !diskmon_load_config() )
         diskmon_use_defaults();
@@ -929,5 +928,5 @@ module_fini(void)
 
     diskmon_free_config();
 
-    dsme_log(LOG_DEBUG, "diskmonitor.so unloaded");
+    dsme_log(LOG_DEBUG, PFIX "diskmonitor.so unloaded");
 }

--- a/modules/dsme_dbus.c
+++ b/modules/dsme_dbus.c
@@ -397,7 +397,6 @@ dsme_dbus_reply_new(const DsmeDbusMessage *request)
     rsp = message_new(request->connection, msg);
 
 EXIT:
-
     if( msg )
         dbus_message_unref(msg);
 
@@ -419,7 +418,6 @@ dsme_dbus_reply_error(const DsmeDbusMessage *request,
     rsp = message_new(request->connection, msg);
 
 EXIT:
-
     if( msg )
         dbus_message_unref(msg);
 
@@ -456,7 +454,6 @@ dsme_dbus_signal_new(const char *sender,
     sig = message_new(con, msg);
 
 EXIT:
-
     if( msg )
         dbus_message_unref(msg);
 
@@ -983,7 +980,6 @@ service_acquire_name(DsmeDbusService *self)
     self->se_acquired = true;
 
 EXIT:
-
     dbus_error_free(&err);
 
     return;
@@ -1016,7 +1012,6 @@ service_release_name(DsmeDbusService *self)
     dsme_log(LOG_DEBUG, "name %s released", self->se_name);
 
 EXIT:
-
     self->se_acquired  = false;
     self->se_requested = false;
 
@@ -1201,7 +1196,6 @@ manager_message_filter_cb(DBusConnection *con, DBusMessage *msg, void *aptr)
         if( dbus_message_is_method_call(msg,
                                         "org.freedesktop.DBus.Introspectable",
                                         "Introspect") ) {
-
             DBusMessage *rsp = manager_handle_introspect(self, msg);
             if( rsp ) {
                 dbus_connection_send(con, rsp, 0);
@@ -1313,7 +1307,6 @@ static void
 manager_delete(DsmeDbusManager *self)
 {
     if( self ) {
-
         manager_disconnect(self);
 
         manager_rem_handlers_all(self);
@@ -1412,7 +1405,6 @@ manager_disconnect(DsmeDbusManager *self)
     dsme_log(LOG_DEBUG, "disconnected from system bus");
 
 EXIT:
-
     return;
 }
 
@@ -1892,7 +1884,6 @@ dsme_dbus_bus_get_unix_process_id(DBusConnection *conn,
     ack = true, *pid = dta;
 
 EXIT:
-
     if( req )
         dbus_message_unref(req);
 

--- a/modules/dsme_dbus.h
+++ b/modules/dsme_dbus.h
@@ -37,6 +37,11 @@
 #include <dbus/dbus.h>
 
 typedef struct DsmeDbusMessage DsmeDbusMessage;
+typedef struct DsmeDbusTracker DsmeDbusTracker;
+typedef struct DsmeDbusClient DsmeDbusClient;
+
+typedef void (*DsmeDbusTrackerNofify)(DsmeDbusTracker *tracker);
+typedef void (*DsmeDbusClientNofify)(DsmeDbusTracker *tracker, DsmeDbusClient *client);
 
 #define DSME_DBUS_MESSAGE_DUMMY ((DsmeDbusMessage *)(0xaffe0000))
 
@@ -79,6 +84,7 @@ const char* dsme_dbus_message_get_string(const DsmeDbusMessage* msg);
 bool        dsme_dbus_message_get_bool(const DsmeDbusMessage* msg);
 bool        dsme_dbus_message_get_variant_bool(const DsmeDbusMessage* msg);
 const char* dsme_dbus_message_path(const DsmeDbusMessage* msg);
+const char* dsme_dbus_message_sender(const DsmeDbusMessage *msg);
 
 // NOTE: frees the signal; hence not const
 void dsme_dbus_signal_emit(DsmeDbusMessage* sig);
@@ -94,4 +100,13 @@ void dsme_dbus_disconnect(void);
 
 void dsme_dbus_startup(void);
 void dsme_dbus_shutdown(void);
+
+DsmeDbusTracker *dsme_dbus_tracker_create(DsmeDbusTrackerNofify count_changed, DsmeDbusClientNofify  client_added, DsmeDbusClientNofify  client_removed);
+void dsme_dbus_tracker_delete(DsmeDbusTracker *self);
+void dsme_dbus_tracker_delete_at(DsmeDbusTracker **pself);
+void dsme_dbus_tracker_add_client(DsmeDbusTracker *self, const char *name);
+void dsme_dbus_tracker_remove_client(DsmeDbusTracker *self, const char *name);
+unsigned dsme_dbus_tracker_client_count(DsmeDbusTracker *self);
+
+const char *dsme_dbus_client_name(DsmeDbusClient *self);
 #endif

--- a/modules/emergencycalltracker.c
+++ b/modules/emergencycalltracker.c
@@ -40,7 +40,6 @@
 
 #include <string.h>
 
-
 static void send_emergency_call_status(bool ongoing)
 {
     DSM_MSGTYPE_SET_EMERGENCY_CALL_STATE msg =
@@ -63,7 +62,6 @@ static void mce_call_state_ind(const DsmeDbusMessage* ind)
 
       emergency_call_started = true;
       dsme_log(LOG_DEBUG, "Emergency call started");
-
   } else if (emergency_call_started) {
       /* the emergency call is over */
       send_emergency_call_status(false);

--- a/modules/emergencycalltracker.c
+++ b/modules/emergencycalltracker.c
@@ -40,6 +40,8 @@
 
 #include <string.h>
 
+#define PFIX "emergencycalltracker: "
+
 static void send_emergency_call_status(bool ongoing)
 {
     DSM_MSGTYPE_SET_EMERGENCY_CALL_STATE msg =
@@ -61,13 +63,13 @@ static void mce_call_state_ind(const DsmeDbusMessage* ind)
       send_emergency_call_status(true);
 
       emergency_call_started = true;
-      dsme_log(LOG_DEBUG, "Emergency call started");
+      dsme_log(LOG_DEBUG, PFIX "Emergency call started");
   } else if (emergency_call_started) {
       /* the emergency call is over */
       send_emergency_call_status(false);
 
       emergency_call_started = false;
-      dsme_log(LOG_DEBUG, "Emergency call is over");
+      dsme_log(LOG_DEBUG, PFIX "Emergency call is over");
   }
 }
 
@@ -80,13 +82,13 @@ static bool dbus_signals_bound = false;
 
 DSME_HANDLER(DSM_MSGTYPE_DBUS_CONNECTED, client, msg)
 {
-  dsme_log(LOG_DEBUG, "emergencycalltracker: DBUS_CONNECTED");
+  dsme_log(LOG_DEBUG, PFIX "emergencycalltracker: DBUS_CONNECTED");
   dsme_dbus_bind_signals(&dbus_signals_bound, dbus_signals_array);
 }
 
 DSME_HANDLER(DSM_MSGTYPE_DBUS_DISCONNECT, client, msg)
 {
-  dsme_log(LOG_DEBUG, "emergencycalltracker: DBUS_DISCONNECT");
+  dsme_log(LOG_DEBUG, PFIX "emergencycalltracker: DBUS_DISCONNECT");
 }
 
 module_fn_info_t message_handlers[] = {
@@ -101,12 +103,12 @@ void module_init(module_t* handle)
    * Instead, wait for DSM_MSGTYPE_DBUS_CONNECTED.
    */
 
-  dsme_log(LOG_DEBUG, "emergencycalltracker.so loaded");
+  dsme_log(LOG_DEBUG, PFIX "emergencycalltracker.so loaded");
 }
 
 void module_fini(void)
 {
   dsme_dbus_unbind_signals(&dbus_signals_bound, dbus_signals_array);
 
-  dsme_log(LOG_DEBUG, "emergencycalltracker.so unloaded");
+  dsme_log(LOG_DEBUG, PFIX "emergencycalltracker.so unloaded");
 }

--- a/modules/heartbeat.c
+++ b/modules/heartbeat.c
@@ -39,6 +39,8 @@
 
 #include <glib.h>
 
+#define PFIX "heartbeat: "
+
 /** Cached module handle for this plugin */
 static const module_t *this_module = 0;
 
@@ -54,7 +56,7 @@ static gboolean emit_heartbeat_message(GIOChannel*  source,
     // handle errors
     if (condition & (G_IO_ERR | G_IO_HUP | G_IO_NVAL)) {
         // the wd process has probably died; remove the watch & quit
-        dsme_log(LOG_CRIT, "heartbeat: I/O error or HUP, terminating");
+        dsme_log(LOG_CRIT, PFIX "heartbeat: I/O error or HUP, terminating");
         goto cleanup;
     }
 
@@ -62,7 +64,7 @@ static gboolean emit_heartbeat_message(GIOChannel*  source,
     ssize_t n = read(STDIN_FILENO, &c, 1);
 
     if( n == 0 ) {
-        dsme_log(LOG_CRIT, "heartbeat: unexpected EOF, terminating");
+        dsme_log(LOG_CRIT, PFIX "heartbeat: unexpected EOF, terminating");
         goto cleanup;
     }
 
@@ -70,7 +72,7 @@ static gboolean emit_heartbeat_message(GIOChannel*  source,
         if( errno == EINTR || errno == EAGAIN )
             keep_going = true;
         else
-            dsme_log(LOG_CRIT, "heartbeat: read error: %m, terminating");
+            dsme_log(LOG_CRIT, PFIX "heartbeat: read error: %m, terminating");
         goto cleanup;
     }
 
@@ -127,7 +129,7 @@ static void stop_heatbeat(void)
 
 void module_init(module_t* handle)
 {
-    dsme_log(LOG_DEBUG, "heartbeat.so loaded");
+    dsme_log(LOG_DEBUG, PFIX "heartbeat.so loaded");
 
     this_module = handle;
 
@@ -136,7 +138,7 @@ void module_init(module_t* handle)
 
 void module_fini(void)
 {
-    dsme_log(LOG_DEBUG, "heartbeat.so unloaded");
+    dsme_log(LOG_DEBUG, PFIX "heartbeat.so unloaded");
 
     stop_heatbeat();
 }

--- a/modules/heartbeat.c
+++ b/modules/heartbeat.c
@@ -86,7 +86,6 @@ static gboolean emit_heartbeat_message(GIOChannel*  source,
     keep_going = true;
 
 cleanup:
-
     if( !keep_going ) {
         watch_id = 0;
         dsme_main_loop_quit(EXIT_FAILURE);
@@ -111,8 +110,8 @@ static bool start_heartbeat(void)
                               G_IO_IN | G_IO_ERR | G_IO_HUP | G_IO_NVAL,
                               emit_heartbeat_message,
                               0);
-cleanup:
 
+cleanup:
     if( chn )
         g_io_channel_unref(chn);
 

--- a/modules/iphb.c
+++ b/modules/iphb.c
@@ -103,7 +103,6 @@
 /** Where to persistently store alarm state data received from timed */
 #define XTIMED_STATE_FILE     "/var/lib/dsme/timed_state"
 
-
 /** Maximum expected lenght of human readable time stamp */
 #define TIMESTAMP_MAX 64
 
@@ -341,6 +340,7 @@ static void log_time_t(int lev, const char *title, time_t t, time_t now)
 	     tm.tm_min,
 	     tm.tm_sec,
 	     left);
+
 cleanup:
     return;
 }
@@ -592,7 +592,6 @@ xmce_verify_name(void)
     res = true;
 
 cleanup:
-
     if( pc  ) dbus_pending_call_unref(pc);
     if( req ) dbus_message_unref(req);
 
@@ -633,7 +632,6 @@ static bool xmce_cpu_keepalive_wakeup(void)
     res = true;
 
 cleanup:
-
     if( req ) dbus_message_unref(req);
 
     return res;
@@ -811,7 +809,6 @@ cleanup:
  */
 static void linux_alarm_set(time_t delay)
 {
-
     if( linux_alarm_timerfd == -1 )
 	goto cleanup;
 
@@ -862,8 +859,6 @@ static bool linux_alarm_handle_input(void)
     res = true;
 
 cleanup:
-
-
     return res;
 }
 
@@ -885,7 +880,6 @@ static bool android_alarm_init(void)
     }
 
 cleanup:
-
     return android_alarm_fd != -1;
 }
 
@@ -1019,7 +1013,6 @@ static time_t deltatime_get(void)
     dsme_log(LOG_INFO, PFIX"rtc delta is %ld", (long)deltatime_cached);
 
 cleanup:
-
     if( fd != -1 ) close(fd);
 
     return deltatime_cached;
@@ -1050,7 +1043,6 @@ static void deltatime_set(time_t delta)
     }
 
 cleanup:
-
     if( fd != -1 ) close(fd);
 }
 
@@ -1083,14 +1075,12 @@ static void deltatime_update(void)
         deltatime_set(delta);
 
 cleanup:
-
     return;
 }
 
 /* ------------------------------------------------------------------------- *
  * RTC management functionality
  * ------------------------------------------------------------------------- */
-
 
 /** Human readable representation for rtc_need_t enum value
  */
@@ -1265,7 +1255,6 @@ static bool rtc_get_time_raw(struct rtc_time *tod)
     result = true;
 
 cleanup:
-
     return result;
 }
 
@@ -1287,7 +1276,6 @@ static time_t rtc_get_time_tm(struct tm *tm)
     result = rtc_time_to_tm(&tod, tm);
 
 cleanup:
-
     return result;
 }
 
@@ -1317,7 +1305,6 @@ static bool rtc_set_time_raw(struct rtc_time *tod)
     result = true;
 
 cleanup:
-
     return result;
 }
 
@@ -1343,7 +1330,6 @@ static bool rtc_set_time_tm(struct tm *tm)
     result = true;
 
 cleanup:
-
     return result;
 }
 
@@ -1369,7 +1355,6 @@ static bool rtc_set_time_t(time_t t)
     result = true;
 
 cleanup:
-
     return result;
 }
 
@@ -1383,7 +1368,6 @@ static bool rtc_set_time_tv(const struct timeval *rtc)
     result = true;
 
 cleanup:
-
     return result;
 }
 
@@ -1402,7 +1386,6 @@ static bool rtc_get_time_tv(struct timeval *rtc)
     result = true;
 
 cleanup:
-
     return result;
 }
 
@@ -1452,7 +1435,6 @@ static bool rtc_set_alarm_raw(const struct rtc_time *tod, bool enabled)
     result = true;
 
 cleanup:
-
     return result;
 }
 
@@ -1479,7 +1461,6 @@ static bool rtc_set_alarm_tm(const struct tm *tm, bool enabled)
     result = true;
 
 cleanup:
-
     return result;
 }
 
@@ -1530,7 +1511,6 @@ static bool rtc_set_alarm_after(time_t delay)
     result = true;
 
 cleanup:
-
     return result;
 }
 
@@ -1639,7 +1619,6 @@ static bool rtc_handle_input(void)
     result = true;
 
 cleanup:
-
     return result;
 }
 
@@ -1700,7 +1679,6 @@ static bool rtc_attach(void)
     rtc_add_need(RTC_NEED_NONE);
 
 cleanup:
-
     if( fd != -1 ) close(fd);
 
     return rtc_fd != -1;
@@ -2427,7 +2405,6 @@ static char *time_minus(const struct timeval *tv, char *buff, size_t size)
     return *pos = 0, buff;
 }
 
-
 /** Wakeup clients if conditions are met
  *
  * We should arrive here if:
@@ -2539,7 +2516,6 @@ static void clientlist_wakeup_clients_now(const struct timeval *now)
     /* and tell hwwd kicker we are alive */
     hwwd_feeder_sync();
 }
-
 
 /** Timer id for delayed wakeup checking
  *
@@ -2853,7 +2829,6 @@ static bool listenfd_init(void)
     result = true;
 
 cleanup:
-
     // all or nothing
     if( !result )
 	listenfd_quit();
@@ -3043,7 +3018,6 @@ cleanup_ack:
     keep_going = TRUE;
 
 cleanup_nak:
-
     if( !keep_going )
 	dsme_log(LOG_CRIT, PFIX"epoll waiting disabled");
 
@@ -3061,7 +3035,6 @@ static void epollfd_quit(void)
 
     if( epollfd != -1 )
 	close(epollfd), epollfd = -1;
-
 }
 
 /** Start the epoll io watch
@@ -3091,7 +3064,6 @@ static bool epollfd_init(void)
     result = true;
 
 cleanup:
-
     if( chan )
 	g_io_channel_unref(chan);
 
@@ -3119,7 +3091,6 @@ static void systembus_connect(void)
     xmce_handle_dbus_connect();
 
 cleanup:
-
     dbus_error_free(&err);
 }
 
@@ -3192,7 +3163,6 @@ DSME_HANDLER(DSM_MSGTYPE_WAIT, conn, msg)
 	 * -> skip wakeup scanning and just feed the hwhw kicker */
 	hwwd_feeder_sync();
     }
-
 }
 
 /** Handle connected to system bus */
@@ -3424,7 +3394,6 @@ void module_init(module_t *handle)
     success = true;
 
 cleanup:
-
     if( success )
         dsme_log(LOG_INFO, PFIX"iphb started");
     else

--- a/modules/iphb.c
+++ b/modules/iphb.c
@@ -320,7 +320,7 @@ static void log_time_t(int lev, const char *title, time_t t, time_t now)
     char left[32];
 
     if( t <= 0 ) {
-	dsme_log(lev, PFIX"%s: not set", title);
+	dsme_log(lev, PFIX "%s: not set", title);
 	goto cleanup;
     }
 
@@ -331,7 +331,7 @@ static void log_time_t(int lev, const char *title, time_t t, time_t now)
     memset(&tm, 0, sizeof tm);
     gmtime_r(&t, &tm);
 
-    dsme_log(lev, PFIX"%s: %04d-%02d-%02d %02d:%02d:%02d%s",
+    dsme_log(lev, PFIX "%s: %04d-%02d-%02d %02d:%02d:%02d%s",
 	     title,
 	     tm.tm_year + 1900,
 	     tm.tm_mon + 1,
@@ -357,7 +357,7 @@ static void hwwd_feeder_sync(void)
       static bool already_logged = false;
       if( !already_logged ) {
         already_logged = true;
-        dsme_log(LOG_WARNING, "valgrind mode: parent SIGHUP skipped");
+        dsme_log(LOG_WARNING, PFIX "valgrind mode: parent SIGHUP skipped");
       }
     }
     else {
@@ -399,17 +399,17 @@ static void wakelock_write(const char *path, const char *data, int ignore)
     int file;
 
     if( (file = TEMP_FAILURE_RETRY(open(path, O_WRONLY))) == -1 ) {
-	dsme_log(LOG_WARNING, PFIX"%s: open: %m", path);
+	dsme_log(LOG_WARNING, PFIX "%s: open: %m", path);
     }
     else {
 	int size = strlen(data);
 	errno = 0;
 	if( TEMP_FAILURE_RETRY(write(file, data, size)) != size ) {
 	    if( errno != ignore )
-		dsme_log(LOG_WARNING, PFIX"%s: write: %m", path);
+		dsme_log(LOG_WARNING, PFIX "%s: write: %m", path);
 	}
 	if( TEMP_FAILURE_RETRY(close(file)) == -1 ) {
-	    dsme_log(LOG_WARNING, PFIX"%s: close: %m", path);
+	    dsme_log(LOG_WARNING, PFIX "%s: close: %m", path);
 	}
     }
 }
@@ -422,7 +422,7 @@ static void wakelock_write(const char *path, const char *data, int ignore)
  */
 static void wakelock_lock(const char *name, int ms)
 {
-    dsme_log(LOG_DEBUG, PFIX"LOCK: %s %d", name, ms);
+    dsme_log(LOG_DEBUG, PFIX "LOCK: %s %d", name, ms);
     if( wakelock_supported() ) {
 	char tmp[256];
 	int rc = -1;
@@ -446,7 +446,7 @@ static void wakelock_lock(const char *name, int ms)
  */
 static void wakelock_unlock(const char *name)
 {
-    dsme_log(LOG_DEBUG, PFIX"UNLK: %s", name);
+    dsme_log(LOG_DEBUG, PFIX "UNLK: %s", name);
     if( wakelock_supported() ) {
 	char tmp[256];
 	int rc = snprintf(tmp, sizeof tmp, "%s\n", name);
@@ -502,7 +502,7 @@ xdbus_parse_name_owner_rsp(DBusMessage *rsp)
 			       DBUS_TYPE_STRING, &dta,
 			       DBUS_TYPE_INVALID) ) {
 	if( strcmp(err.name, DBUS_ERROR_NAME_HAS_NO_OWNER) ) {
-	    dsme_log(LOG_WARNING, PFIX"%s: %s", err.name, err.message);
+	    dsme_log(LOG_WARNING, PFIX "%s: %s", err.name, err.message);
 	}
 	goto cleanup;
     }
@@ -526,7 +526,7 @@ static void xmce_set_runstate(bool running)
 {
     if( mce_is_running != running ) {
 	mce_is_running = running;
-	dsme_log(LOG_INFO, PFIX"mce state -> %s",
+	dsme_log(LOG_INFO, PFIX "mce state -> %s",
 		 running ? "running" : "terminated");
     }
 }
@@ -624,7 +624,7 @@ static bool xmce_cpu_keepalive_wakeup(void)
     dbus_message_set_no_reply(req, true);
 
     if( !dbus_connection_send(systembus, req, 0) ) {
-	dsme_log(LOG_WARNING, PFIX"failed to send %s.%s", MCE_REQUEST_IF,
+	dsme_log(LOG_WARNING, PFIX "failed to send %s.%s", MCE_REQUEST_IF,
 		 MCE_CPU_KEEPALIVE_WAKEUP_REQ);
 	goto cleanup;
     }
@@ -683,7 +683,7 @@ xmce_dbus_filter_cb(DBusConnection *con, DBusMessage *msg, void *user_data)
 			       DBUS_TYPE_STRING, &prev,
 			       DBUS_TYPE_STRING, &curr,
 			       DBUS_TYPE_INVALID) ) {
-	dsme_log(LOG_WARNING, PFIX"%s: %s", err.name, err.message);
+	dsme_log(LOG_WARNING, PFIX "%s: %s", err.name, err.message);
 	goto cleanup;
     }
 
@@ -756,12 +756,12 @@ static bool linux_alarm_init(void)
     if( fd == -1 ) {
 	/* Having alarm via timerfd is just one option - do not
 	 * complain by default if kernel does not support it */
-	dsme_log(LOG_INFO, PFIX"%s: %m", "timerfd_create");
+	dsme_log(LOG_INFO, PFIX "%s: %m", "timerfd_create");
 	goto cleanup;
     }
 
     if( !epollfd_add_fd(fd, &linux_alarm_timerfd)) {
-	dsme_log(LOG_WARNING, PFIX"failed to add timer fd to epoll set");
+	dsme_log(LOG_WARNING, PFIX "failed to add timer fd to epoll set");
 	goto cleanup;
     }
 
@@ -799,7 +799,7 @@ static void linux_alarm_clear(void)
     struct itimerspec it = {{0,0}, {0,0}};
 
     if( timerfd_settime(linux_alarm_timerfd, TFD_TIMER_ABSTIME, &it, 0) == -1 )
-	dsme_log(LOG_ERR, PFIX"timerfd %s: %m", "timerfd_settime");
+	dsme_log(LOG_ERR, PFIX "timerfd %s: %m", "timerfd_settime");
 
 cleanup:
     return;
@@ -817,7 +817,7 @@ static void linux_alarm_set(time_t delay)
     struct timespec now = { .tv_sec = 0, .tv_nsec = 0 };
 
     if( clock_gettime(linux_alarm_clockid, &now) == -1 ) {
-	dsme_log(LOG_ERR, PFIX"timerfd %s: %m", "clock_gettime");
+	dsme_log(LOG_ERR, PFIX "timerfd %s: %m", "clock_gettime");
 	goto cleanup;
     }
 
@@ -827,12 +827,12 @@ static void linux_alarm_set(time_t delay)
     it.it_value.tv_sec += delay;
 
     if( timerfd_settime(linux_alarm_timerfd, TFD_TIMER_ABSTIME, &it, 0) == -1 ) {
-	dsme_log(LOG_ERR, PFIX"timerfd %s: %m", "timerfd_settime");
+	dsme_log(LOG_ERR, PFIX "timerfd %s: %m", "timerfd_settime");
 	goto cleanup;
     }
 
-    dsme_log(LOG_DEBUG, PFIX"timerfd time  : %s", t_repr(now.tv_sec, tmp, sizeof tmp));
-    dsme_log(LOG_DEBUG, PFIX"timerfd alarm : %s", t_repr(it.it_value.tv_sec, tmp, sizeof tmp));
+    dsme_log(LOG_DEBUG, PFIX "timerfd time  : %s", t_repr(now.tv_sec, tmp, sizeof tmp));
+    dsme_log(LOG_DEBUG, PFIX "timerfd alarm : %s", t_repr(it.it_value.tv_sec, tmp, sizeof tmp));
 
 cleanup:
     return;
@@ -855,7 +855,7 @@ static bool linux_alarm_handle_input(void)
 	    goto cleanup;
     }
 
-    dsme_log(LOG_DEBUG, PFIX"timerfd alarm: triggered");
+    dsme_log(LOG_DEBUG, PFIX "timerfd alarm: triggered");
     res = true;
 
 cleanup:
@@ -876,7 +876,7 @@ static bool android_alarm_init(void)
     if( (android_alarm_fd = open(android_alarm_path, O_RDWR)) == -1 ) {
 	/* Using /dev/alarm is optional; do not complain if it is missing */
 	if( errno != ENOENT )
-	    dsme_log(LOG_WARNING, PFIX"%s: %m", android_alarm_path);
+	    dsme_log(LOG_WARNING, PFIX "%s: %m", android_alarm_path);
     }
 
 cleanup:
@@ -908,7 +908,7 @@ static void android_alarm_set(time_t delay)
 
     int get_time = ANDROID_ALARM_GET_TIME(ANDROID_ALARM_RTC);
     if( ioctl(android_alarm_fd, get_time, &now) != 0 ) {
-	dsme_log(LOG_ERR, PFIX"%s: %m", "ANDROID_ALARM_TIME_GET");
+	dsme_log(LOG_ERR, PFIX "%s: %m", "ANDROID_ALARM_TIME_GET");
 	goto cleanup;
     }
 
@@ -917,14 +917,14 @@ static void android_alarm_set(time_t delay)
 
     int set_alarm = ANDROID_ALARM_SET(ANDROID_ALARM_RTC_WAKEUP);
     if( ioctl(android_alarm_fd, set_alarm, &wup) != 0 ) {
-	dsme_log(LOG_ERR, PFIX"%s: %m", "ANDROID_ALARM_SET");
+	dsme_log(LOG_ERR, PFIX "%s: %m", "ANDROID_ALARM_SET");
 	goto cleanup;
     }
 
     if( android_alarm_prev != wup.tv_sec ) {
 	android_alarm_prev = wup.tv_sec;
-	dsme_log(LOG_INFO, PFIX"android time:  %s", t_repr(now.tv_sec, tmp, sizeof tmp));
-	dsme_log(LOG_INFO, PFIX"android alarm: %s", t_repr(wup.tv_sec, tmp, sizeof tmp));
+	dsme_log(LOG_INFO, PFIX "android time:  %s", t_repr(now.tv_sec, tmp, sizeof tmp));
+	dsme_log(LOG_INFO, PFIX "android alarm: %s", t_repr(wup.tv_sec, tmp, sizeof tmp));
     }
 
 cleanup:
@@ -941,13 +941,13 @@ static void android_alarm_clear(void)
     int cmd = ANDROID_ALARM_CLEAR(ANDROID_ALARM_RTC_WAKEUP);
 
     if( ioctl(android_alarm_fd, cmd) != 0 ) {
-	dsme_log(LOG_ERR, PFIX"%s: %m", "ANDROID_ALARM_CLEAR");
+	dsme_log(LOG_ERR, PFIX "%s: %m", "ANDROID_ALARM_CLEAR");
 	goto cleanup;
     }
 
     if( android_alarm_prev != -1 ) {
 	android_alarm_prev = -1;
-	dsme_log(LOG_INFO, PFIX"android alarm wakeup removed");
+	dsme_log(LOG_INFO, PFIX "android alarm wakeup removed");
     }
 
 cleanup:
@@ -995,14 +995,14 @@ static time_t deltatime_get(void)
 
     if( (fd = open(DELTATIME_CACHE_FILE, O_RDONLY)) == -1 ) {
         if( errno != ENOENT )
-            dsme_log(LOG_ERR, PFIX"%s: %s: %m", DELTATIME_CACHE_FILE, "open");
+            dsme_log(LOG_ERR, PFIX "%s: %s: %m", DELTATIME_CACHE_FILE, "open");
         goto cleanup;
     }
 
     char tmp[32];
     int len = read(fd, tmp, sizeof tmp - 1);
     if( len < 0 ) {
-        dsme_log(LOG_ERR, PFIX"%s: %s: %m", DELTATIME_CACHE_FILE, "read");
+        dsme_log(LOG_ERR, PFIX "%s: %s: %m", DELTATIME_CACHE_FILE, "read");
         goto cleanup;
     }
 
@@ -1010,7 +1010,7 @@ static time_t deltatime_get(void)
 
     deltatime_cached = strtol(tmp, 0, 0);
 
-    dsme_log(LOG_INFO, PFIX"rtc delta is %ld", (long)deltatime_cached);
+    dsme_log(LOG_INFO, PFIX "rtc delta is %ld", (long)deltatime_cached);
 
 cleanup:
     if( fd != -1 ) close(fd);
@@ -1026,11 +1026,11 @@ static void deltatime_set(time_t delta)
 
     deltatime_cached = delta;
 
-    dsme_log(LOG_WARNING, PFIX"rtc delta to %ld", (long)deltatime_cached);
+    dsme_log(LOG_WARNING, PFIX "rtc delta to %ld", (long)deltatime_cached);
 
     fd = open(DELTATIME_CACHE_FILE, O_WRONLY|O_CREAT|O_TRUNC, 0644);
     if( fd == -1 ) {
-        dsme_log(LOG_ERR, PFIX"%s: %s: %m", DELTATIME_CACHE_FILE, "open");
+        dsme_log(LOG_ERR, PFIX "%s: %s: %m", DELTATIME_CACHE_FILE, "open");
         goto cleanup;
     }
 
@@ -1038,7 +1038,7 @@ static void deltatime_set(time_t delta)
     int len = snprintf(tmp, sizeof tmp, "%ld\n", (long)delta);
 
     if( len > 0 && len < sizeof tmp && write(fd, tmp, len) == -1 ) {
-        dsme_log(LOG_ERR, PFIX"%s: %s: %m", DELTATIME_CACHE_FILE, "write");
+        dsme_log(LOG_ERR, PFIX "%s: %s: %m", DELTATIME_CACHE_FILE, "write");
         goto cleanup;
     }
 
@@ -1098,7 +1098,7 @@ static gboolean rtc_need_ended_cb(gpointer aptr)
 {
     (void)aptr;
     rtc_need_ended_id = 0;
-    dsme_log(LOG_INFO, PFIX"rtc no longer needed");
+    dsme_log(LOG_INFO, PFIX "rtc no longer needed");
     rtc_detach();
     return G_SOURCE_REMOVE;
 }
@@ -1111,7 +1111,7 @@ static gboolean rtc_need_ended_cb(gpointer aptr)
 static void rtc_set_need(rtc_need_t need)
 {
     if( rtc_need != need ) {
-        dsme_log(LOG_INFO, PFIX"rtc need: %s -> %s",
+        dsme_log(LOG_INFO, PFIX "rtc need: %s -> %s",
                  rtc_need_repr(rtc_need),
                  rtc_need_repr(need));
         rtc_need = need;
@@ -1246,11 +1246,11 @@ static bool rtc_get_time_raw(struct rtc_time *tod)
     memset(tod, 0, sizeof *tod);
 
     if( ioctl(rtc_fd, RTC_RD_TIME, tod) == -1 ) {
-	dsme_log(LOG_ERR, PFIX"%s: %s: %m", rtc_path, "RTC_RD_TIME");
+	dsme_log(LOG_ERR, PFIX "%s: %s: %m", rtc_path, "RTC_RD_TIME");
 	goto cleanup;
     }
 
-    rtc_log_time(LOG_DEBUG, PFIX"rtc time is: ", tod);
+    rtc_log_time(LOG_DEBUG, PFIX "rtc time is: ", tod);
 
     result = true;
 
@@ -1296,11 +1296,11 @@ static bool rtc_set_time_raw(struct rtc_time *tod)
 	/* In many devices the rtc time of day can't be changed
 	 * and a failure to do just activates the "deltatime"
 	 * workaround -> do not complain in default verbosity. */
-	dsme_log(LOG_INFO, PFIX"%s: %s: %m", rtc_path, "RTC_SET_TIME");
+	dsme_log(LOG_INFO, PFIX "%s: %s: %m", rtc_path, "RTC_SET_TIME");
 	goto cleanup;
     }
 
-    rtc_log_time(LOG_INFO, PFIX"set rtc time to: ", tod);
+    rtc_log_time(LOG_INFO, PFIX "set rtc time to: ", tod);
 
     result = true;
 
@@ -1417,12 +1417,12 @@ static bool rtc_set_alarm_raw(const struct rtc_time *tod, bool enabled)
     }
 
     if( enabled )
-	rtc_log_time(LOG_INFO, PFIX"set rtc wakeup alarm at ", tod);
+	rtc_log_time(LOG_INFO, PFIX "set rtc wakeup alarm at ", tod);
     else if( prev.enabled )
-	dsme_log(LOG_INFO, PFIX"disable rtc wakeup alarm");
+	dsme_log(LOG_INFO, PFIX "disable rtc wakeup alarm");
 
     if( ioctl(rtc_fd, RTC_WKALM_SET, &alrm) == -1 ) {
-	dsme_log(LOG_ERR, PFIX"%s: %s: %m", rtc_path, "RTC_WKALM_SET");
+	dsme_log(LOG_ERR, PFIX "%s: %s: %m", rtc_path, "RTC_WKALM_SET");
 	goto cleanup;
     }
 
@@ -1481,9 +1481,9 @@ static bool rtc_set_alarm_after(time_t delay)
     struct tm tm;
     char tmp[TIMESTAMP_MAX];
 
-    dsme_log(LOG_INFO, PFIX"wakeup delay %d", (int)delay);
-    dsme_log(LOG_INFO, PFIX"system : %s", t_repr(sys, tmp, sizeof tmp));
-    dsme_log(LOG_INFO, PFIX"alarm  : %s", t_repr(alm, tmp, sizeof tmp));
+    dsme_log(LOG_INFO, PFIX "wakeup delay %d", (int)delay);
+    dsme_log(LOG_INFO, PFIX "system : %s", t_repr(sys, tmp, sizeof tmp));
+    dsme_log(LOG_INFO, PFIX "alarm  : %s", t_repr(alm, tmp, sizeof tmp));
 
     if( !rtc_attach() )
 	goto cleanup;
@@ -1540,12 +1540,12 @@ static void rtc_set_alarm_powerup(void)
 
     /* encrypted home implies: act dead alarms are not supported */
     if( rtc && dsme_home_is_encrypted() ) {
-	dsme_log(LOG_WARNING, PFIX"home encrypted; skip wakeup alarm");
+	dsme_log(LOG_WARNING, PFIX "home encrypted; skip wakeup alarm");
 	rtc = 0;
     }
 
     /* always log the state we leave rtc wakeup on dsme exit */
-    log_time_t(LOG_WARNING, PFIX"powerup via RTC", rtc ? sys+rtc : 0, sys);
+    log_time_t(LOG_WARNING, PFIX "powerup via RTC", rtc ? sys+rtc : 0, sys);
 
     if( rtc_get_time_tm(&tm) != (time_t)-1 ) {
       	tm.tm_sec += rtc;
@@ -1565,10 +1565,10 @@ static bool rtc_handle_input(void)
     bool result = false;
     long status = 0;
 
-    dsme_log(LOG_INFO, PFIX"wakeup via RTC alarm");
+    dsme_log(LOG_INFO, PFIX "wakeup via RTC alarm");
 
     if( rtc_fd == -1 ) {
-	dsme_log(LOG_WARNING, PFIX"failed to read %s: %s",  rtc_path,
+	dsme_log(LOG_WARNING, PFIX "failed to read %s: %s",  rtc_path,
 		"the device node is not opened");
 	goto cleanup;
     }
@@ -1578,7 +1578,7 @@ static bool rtc_handle_input(void)
     errno = 0;
 
     if( read(rtc_fd, &status, sizeof status) != sizeof status ) {
-	dsme_log(LOG_WARNING, PFIX"failed to read %s: %m",  rtc_path);
+	dsme_log(LOG_WARNING, PFIX "failed to read %s: %m",  rtc_path);
 	goto cleanup;
     }
 
@@ -1591,13 +1591,13 @@ static bool rtc_handle_input(void)
 	struct timeval tv;
 
 	if( deltatime_is_needed )
-	    dsme_log(LOG_INFO, PFIX"rtc not writable; not using it as system time source");
+	    dsme_log(LOG_INFO, PFIX "rtc not writable; not using it as system time source");
 	else if( !rtc_get_time_tv(&tv) )
-	    dsme_log(LOG_WARNING, PFIX"failed to read rtc time");
+	    dsme_log(LOG_WARNING, PFIX "failed to read rtc time");
 	else if( settimeofday(&tv, 0) == -1 )
-	    dsme_log(LOG_WARNING, PFIX"failed to set system time");
+	    dsme_log(LOG_WARNING, PFIX "failed to set system time");
 	else
-	    dsme_log(LOG_INFO, PFIX"system time set from rtc");
+	    dsme_log(LOG_INFO, PFIX "system time set from rtc");
 
 	/* Keep the update interrupts active for few more rounds to
 	 * make sure we get stable rtc delta statistics */
@@ -1611,7 +1611,7 @@ static bool rtc_handle_input(void)
 
 	if( --deltatime_updates_todo == 0 ) {
 	    if( ioctl(rtc_fd, RTC_UIE_OFF, 0) == -1 )
-		dsme_log(LOG_WARNING, PFIX"failed to disable update interrupts");
+		dsme_log(LOG_WARNING, PFIX "failed to disable update interrupts");
             rtc_remove_need(RTC_NEED_UPDATES);
 	}
     }
@@ -1638,7 +1638,7 @@ static void rtc_detach(void)
 	epollfd_remove_fd(rtc_fd);
 	close(rtc_fd), rtc_fd = -1;
 
-	dsme_log(LOG_INFO, PFIX"closed %s", rtc_path);
+	dsme_log(LOG_INFO, PFIX "closed %s", rtc_path);
     }
 }
 
@@ -1656,18 +1656,18 @@ static bool rtc_attach(void)
 	goto cleanup;
 
     if( (fd = open(rtc_path, O_RDONLY)) == -1 ) {
-	dsme_log(LOG_WARNING, PFIX"failed to open %s: %m", rtc_path);
+	dsme_log(LOG_WARNING, PFIX "failed to open %s: %m", rtc_path);
 	goto cleanup;
     }
 
     if( !epollfd_add_fd(fd, &rtc_fd)) {
-	dsme_log(LOG_WARNING, PFIX"failed to add rtc fd to epoll set");
+	dsme_log(LOG_WARNING, PFIX "failed to add rtc fd to epoll set");
 	goto cleanup;
     }
 
     /* N.B. rtc_xxx utilities can be called after rtc_fd is set */
     rtc_fd = fd, fd = -1;
-    dsme_log(LOG_INFO, PFIX"opened %s", rtc_path);
+    dsme_log(LOG_INFO, PFIX "opened %s", rtc_path);
 
     /* deal with obviously wrong rtc time values */
     if( !systemtime_initialized ) {
@@ -1728,28 +1728,28 @@ static void kernelfd_open(void)
 	     * Not having it just means we are missing one wakeup source to
 	     * synchronize with i.e. no need to create noise about it on
 	     * default verbosity level */
-	    dsme_log(LOG_INFO, PFIX"kernel does not support iphb wakeups");
+	    dsme_log(LOG_INFO, PFIX "kernel does not support iphb wakeups");
 	}
 	else
-	    dsme_log(LOG_ERR, PFIX"failed to open kernel connection '%s' (%m)",
+	    dsme_log(LOG_ERR, PFIX "failed to open kernel connection '%s' (%m)",
 		     HB_KERNEL_DEVICE);
     }
 
     return;
 
 initialize:
-    dsme_log(LOG_DEBUG, PFIX"opened kernel socket %d to %s, "
+    dsme_log(LOG_DEBUG, PFIX "opened kernel socket %d to %s, "
 	     "wakeup from kernel=%s",
 	     kernelfd,
 	     HB_KERNEL_DEVICE,
 	     msg);
 
     if( write(kernelfd, msg, sizeof msg) == -1 ) {
-	dsme_log(LOG_ERR, PFIX"failed to write kernel message (%m)");
+	dsme_log(LOG_ERR, PFIX "failed to write kernel message (%m)");
 	// TODO: do something clever?
     }
     else if( !epollfd_add_fd(kernelfd, &kernelfd) ) {
-	dsme_log(LOG_ERR, PFIX"failed to add kernel fd to epoll set");
+	dsme_log(LOG_ERR, PFIX "failed to add kernel fd to epoll set");
 	// TODO: do something clever?
     }
 }
@@ -1760,7 +1760,7 @@ static void kernelfd_close(void)
     if( kernelfd != -1 ) {
 	epollfd_remove_fd(kernelfd);
         close(kernelfd);
-        dsme_log(LOG_DEBUG, PFIX"closed kernel socket %d", kernelfd);
+        dsme_log(LOG_DEBUG, PFIX "closed kernel socket %d", kernelfd);
         kernelfd = -1;
     }
 }
@@ -1867,7 +1867,7 @@ static bool client_wakeup(client_t *self, const struct timeval *now)
 
     timersub(now, &self->reqtime, &tv);
 
-    dsme_log(LOG_DEBUG, PFIX"waking up client %s who has slept %ld secs",
+    dsme_log(LOG_DEBUG, PFIX "waking up client %s who has slept %ld secs",
 	     self->pidtxt, (long)tv.tv_sec);
 
     if( client_is_external(self) ) {
@@ -2035,10 +2035,10 @@ static bool client_handle_wait_req(client_t                      *self,
     if( mintime == 0 && maxtime == 0 ) {
 	/* connect/cancel */
         if (!self->pid) {
-            dsme_log(LOG_DEBUG, PFIX"client %s connected", self->pidtxt);
+            dsme_log(LOG_DEBUG, PFIX "client %s connected", self->pidtxt);
         }
 	else {
-            dsme_log(LOG_DEBUG, PFIX"client %s canceled wait", self->pidtxt);
+            dsme_log(LOG_DEBUG, PFIX "client %s canceled wait", self->pidtxt);
             client_woken = true;
         }
 	/* mark as not-started */
@@ -2049,10 +2049,10 @@ static bool client_handle_wait_req(client_t                      *self,
 	mintime = client_adjust_period(mintime);
 
 	if( mintime != req_mintime )
-	    dsme_log(LOG_DEBUG, PFIX"client %s adjusted slot: %d -> %d",
+	    dsme_log(LOG_DEBUG, PFIX "client %s adjusted slot: %d -> %d",
 		     self->pidtxt, req_mintime, mintime);
 
-	dsme_log(LOG_DEBUG, PFIX"client %s wakeup at %d slot",
+	dsme_log(LOG_DEBUG, PFIX "client %s wakeup at %d slot",
 		 self->pidtxt, mintime);
 
 	mintime = maxtime = mintime - (mintime + now->tv_sec) % mintime;
@@ -2066,10 +2066,10 @@ static bool client_handle_wait_req(client_t                      *self,
 	mintime = client_adjust_mintime(mintime, maxtime);
 
 	if( mintime != req_mintime )
-	    dsme_log(LOG_DEBUG, PFIX"client %s adjusted mintime: %d -> %d",
+	    dsme_log(LOG_DEBUG, PFIX "client %s adjusted mintime: %d -> %d",
 		     self->pidtxt, req_mintime, mintime);
 
-	dsme_log(LOG_DEBUG, PFIX"client %s wakeup at %d-%d range",
+	dsme_log(LOG_DEBUG, PFIX "client %s wakeup at %d-%d range",
 		 self->pidtxt, mintime, maxtime);
     }
 
@@ -2084,7 +2084,7 @@ static bool client_handle_wait_req(client_t                      *self,
 	self->wakeup = (req->wakeup != 0);
 
     if( self->wakeup )
-	dsme_log(LOG_DEBUG, PFIX"client %s wakeup flag set", self->pidtxt);
+	dsme_log(LOG_DEBUG, PFIX "client %s wakeup flag set", self->pidtxt);
 
     return client_woken;
 }
@@ -2125,7 +2125,7 @@ static void client_handle_stat_req(client_t *self)
 
     if( send(self->fd, &stats, sizeof stats, flags) != sizeof stats )
     {
-        dsme_log(LOG_ERR, PFIX"failed to send to client %s (%m)",
+        dsme_log(LOG_ERR, PFIX "failed to send to client %s (%m)",
 		 self->pidtxt);
 	// do not drop yet
     }
@@ -2292,7 +2292,7 @@ static void clientlist_rethink_rtc_wakeup(const struct timeval *now)
      * now and then to drive the battery monitoring during suspend */
 #if RTC_MAXIMUM_WAKEUP_TIME
     if( sleeptime < 0 || sleeptime > RTC_MAXIMUM_WAKEUP_TIME ) {
-	dsme_log(LOG_DEBUG, PFIX"truncating sleep: %ld -> %ld seconds",
+	dsme_log(LOG_DEBUG, PFIX "truncating sleep: %ld -> %ld seconds",
 		 (long)sleeptime, (long)RTC_MAXIMUM_WAKEUP_TIME);
 	sleeptime = RTC_MAXIMUM_WAKEUP_TIME;
     }
@@ -2323,7 +2323,7 @@ static gboolean clientlist_handle_wakeup_timeout(gpointer userdata)
 
     wakeup_timer = 0;
 
-    dsme_log(LOG_DEBUG, PFIX"wakeup via normal timer");
+    dsme_log(LOG_DEBUG, PFIX "wakeup via normal timer");
 
     struct timeval   tv_now;
     monotime_get_tv(&tv_now);
@@ -2345,7 +2345,7 @@ static void clientlist_start_wakeup_timeout(const struct timeval *sleep_time)
 
     int ms = sleep_time->tv_sec * 1000 + sleep_time->tv_usec / 1000;
 
-    dsme_log(LOG_DEBUG, PFIX"setting a wakeup in %d ms", ms);
+    dsme_log(LOG_DEBUG, PFIX "setting a wakeup in %d ms", ms);
     wakeup_timer = dsme_create_timer(ms, clientlist_handle_wakeup_timeout, 0);
 }
 
@@ -2424,7 +2424,7 @@ static void clientlist_wakeup_clients_now(const struct timeval *now)
     struct timeval tv_to_min;
     char stamp[64];
 
-    dsme_log(LOG_DEBUG, PFIX"check if clients need waking up");
+    dsme_log(LOG_DEBUG, PFIX "check if clients need waking up");
     clientlist_wakeup_clients_cancel();
     clientlist_cancel_wakeup_timeout();
 
@@ -2446,7 +2446,7 @@ static void clientlist_wakeup_clients_now(const struct timeval *now)
 	    continue;
 
 	/* mintime passed and maxtime is less than heartbeat away */
-	dsme_log(LOG_DEBUG, PFIX"client %s must be woken up", client->pidtxt);
+	dsme_log(LOG_DEBUG, PFIX "client %s must be woken up", client->pidtxt);
 	must_wake = true;
 	break;
     }
@@ -2457,7 +2457,7 @@ static void clientlist_wakeup_clients_now(const struct timeval *now)
 	next = client->next;
 
         if( !client_wait_started(client) ) {
-            dsme_log(LOG_DEBUG, PFIX"client %s not scheduled", client->pidtxt);
+            dsme_log(LOG_DEBUG, PFIX "client %s not scheduled", client->pidtxt);
 	    continue;
         }
 
@@ -2465,7 +2465,7 @@ static void clientlist_wakeup_clients_now(const struct timeval *now)
 
 	if( tv_lt(now, &client->mintime) ) {
 	    timersub(&client->mintime, now, &tv_to_min);
-	    dsme_log(LOG_DEBUG, PFIX"client %s min wakeup %s",
+	    dsme_log(LOG_DEBUG, PFIX "client %s min wakeup %s",
 		     client->pidtxt,
 		     time_minus(&tv_to_min, stamp, sizeof stamp));
 
@@ -2481,14 +2481,14 @@ static void clientlist_wakeup_clients_now(const struct timeval *now)
 	}
 	else if( !must_wake && tv_to_max.tv_sec >= DSME_HEARTBEAT_INTERVAL ) {
 	    /* maxtime is at least one heartbeat away */
-	    dsme_log(LOG_DEBUG, PFIX"client %s max wakeup %s",
+	    dsme_log(LOG_DEBUG, PFIX "client %s max wakeup %s",
 		     client->pidtxt,
 		     time_minus(&tv_to_max, stamp, sizeof stamp));
 	}
 	else {
 	    /* due now, wakeup */
 	    if( !client_wakeup(client, now) ) {
-		dsme_log(LOG_ERR, PFIX"failed to send to client %s (%m),"
+		dsme_log(LOG_ERR, PFIX "failed to send to client %s (%m),"
 			 " drop client", client->pidtxt);
 		clientlist_delete_client(client), client = 0;
 	    }
@@ -2562,7 +2562,7 @@ EXIT:
 static void clientlist_wakeup_clients_cancel(void)
 {
     if( clientlist_wakeup_clients_id ) {
-	dsme_log(LOG_DEBUG, PFIX"cancel delayed wakeup checking");
+	dsme_log(LOG_DEBUG, PFIX "cancel delayed wakeup checking");
 	dsme_destroy_timer(clientlist_wakeup_clients_id),
 	    clientlist_wakeup_clients_id = 0;
 	wakelock_unlock(iphb_wakeup);
@@ -2589,7 +2589,7 @@ static void clientlist_wakeup_clients_later(const struct timeval *now)
     (void)now;
 
     if( !clientlist_wakeup_clients_id ) {
-	dsme_log(LOG_DEBUG, PFIX"schedule delayed wakeup checking");
+	dsme_log(LOG_DEBUG, PFIX "schedule delayed wakeup checking");
 	wakelock_lock(iphb_wakeup, -1);
 	clientlist_wakeup_clients_id =
 	    dsme_create_timer(200, clientlist_wakeup_clients_cb, 0);
@@ -2624,7 +2624,7 @@ static void xtimed_alarm_status_cb(const DsmeDbusMessage* ind)
     time_t new_resume  = dsme_dbus_message_get_int(ind);
     time_t sys = time(0);
 
-    dsme_log(LOG_NOTICE, PFIX"alarm state from timed: powerup=%ld, resume=%ld",
+    dsme_log(LOG_NOTICE, PFIX "alarm state from timed: powerup=%ld, resume=%ld",
 	     (long)new_powerup, (long)new_resume);
 
     if( new_powerup < sys || new_powerup >= INT_MAX )
@@ -2655,7 +2655,7 @@ static void xtimed_alarm_status_cb(const DsmeDbusMessage* ind)
  */
 static void xtimed_config_status_cb(const DsmeDbusMessage* ind)
 {
-    dsme_log(LOG_INFO, PFIX"settings change from timed");
+    dsme_log(LOG_INFO, PFIX "settings change from timed");
 
     /* rethink will sync rtc time with system time */
     struct timeval now;
@@ -2674,34 +2674,34 @@ static void xtimed_status_save(void)
   int rc;
 
   if( remove(temp) == -1 && errno != ENOENT ) {
-    dsme_log(LOG_ERR, PFIX"%s: %s: %m", temp, "remove");
+    dsme_log(LOG_ERR, PFIX "%s: %s: %m", temp, "remove");
     goto cleanup;
   }
 
   if( !(file = fopen(temp, "w")) ) {
-    dsme_log(LOG_ERR, PFIX"%s: %s: %m", temp, "open");
+    dsme_log(LOG_ERR, PFIX "%s: %s: %m", temp, "open");
     goto cleanup;
   }
 
   rc = fprintf(file, "%ld %ld\n", (long)alarm_powerup, (long)alarm_resume);
   if( rc < 0 ) {
-    dsme_log(LOG_ERR, PFIX"%s: %s: %m", temp, "write");
+    dsme_log(LOG_ERR, PFIX "%s: %s: %m", temp, "write");
     goto cleanup;
   }
 
   if( fflush(file) == EOF ) {
-    dsme_log(LOG_ERR, PFIX"%s: %s: %m", temp, "flush");
+    dsme_log(LOG_ERR, PFIX "%s: %s: %m", temp, "flush");
     goto cleanup;
   }
 
   rc = fclose(file), file = 0;
   if( rc == EOF ) {
-    dsme_log(LOG_ERR, PFIX"%s: %s: %m", temp, "close");
+    dsme_log(LOG_ERR, PFIX "%s: %s: %m", temp, "close");
     goto cleanup;
   }
 
   if( rename(temp, path) == -1 ) {
-    dsme_log(LOG_ERR, PFIX"%s: rename to %s: %m", temp, path);
+    dsme_log(LOG_ERR, PFIX "%s: rename to %s: %m", temp, path);
   }
 
 cleanup:
@@ -2718,14 +2718,14 @@ static void xtimed_status_load(void)
 
   if( !(file = fopen(path, "r")) ) {
       if( errno != ENOENT )
-	  dsme_log(LOG_ERR, PFIX"%s: %s: %m", path, "open");
+	  dsme_log(LOG_ERR, PFIX "%s: %s: %m", path, "open");
     goto cleanup;
   }
 
   long powerup = 0, resume = 0;
 
   if( fscanf(file, "%ld %ld", &powerup, &resume) != 2 ) {
-    dsme_log(LOG_ERR, PFIX"%s: %s: did not get two values", path, "read");
+    dsme_log(LOG_ERR, PFIX "%s: %s: did not get two values", path, "read");
     goto cleanup;
   }
   alarm_powerup = (time_t)powerup;
@@ -2746,13 +2746,13 @@ static void listenfd_handle_connect(void)
     int newfd = accept(listenfd, 0, 0);
 
     if( newfd == -1 ) {
-	dsme_log(LOG_ERR, PFIX"failed to accept client (%m)");
+	dsme_log(LOG_ERR, PFIX "failed to accept client (%m)");
     }
     else {
 	client_t *client = client_new_external(newfd);
 	if (epollfd_add_fd(newfd, client)) {
 	    clientlist_add_client(client);
-	    dsme_log(LOG_DEBUG, PFIX"new client added to list");
+	    dsme_log(LOG_DEBUG, PFIX "new client added to list");
 	}
 	else {
 	    clientlist_delete_client(client);
@@ -2771,7 +2771,7 @@ static void listenfd_quit(void)
     }
 
     if( unlink(HB_SOCKET_PATH) == -1 && errno != ENOENT ) {
-        dsme_log(LOG_WARNING, PFIX"failed to remove client listen socket %s: %m",
+        dsme_log(LOG_WARNING, PFIX "failed to remove client listen socket %s: %m",
 		 HB_SOCKET_PATH);
     }
 }
@@ -2788,13 +2788,13 @@ static bool listenfd_init(void)
     struct sockaddr_un addr;
 
     if( unlink(HB_SOCKET_PATH) == -1 && errno != ENOENT ) {
-        dsme_log(LOG_WARNING, PFIX"failed to remove client listen socket %s: %m",
+        dsme_log(LOG_WARNING, PFIX "failed to remove client listen socket %s: %m",
 		 HB_SOCKET_PATH);
 	// try to continue anyway
     }
 
     if( (listenfd = socket(PF_UNIX, SOCK_STREAM, 0)) < 0 ) {
-        dsme_log(LOG_ERR, PFIX"failed to open client listen socket: %m");
+        dsme_log(LOG_ERR, PFIX "failed to open client listen socket: %m");
         goto cleanup;
     }
 
@@ -2802,22 +2802,22 @@ static bool listenfd_init(void)
     strcpy(addr.sun_path, HB_SOCKET_PATH);
 
     if( bind(listenfd, (struct sockaddr *) &addr, sizeof(addr)) == -1 ) {
-        dsme_log(LOG_ERR, PFIX"failed to bind client listen socket to %s: %m",
+        dsme_log(LOG_ERR, PFIX "failed to bind client listen socket to %s: %m",
                  HB_SOCKET_PATH);
         goto cleanup;
     }
 
     if( chmod(HB_SOCKET_PATH, mode) == -1 ) {
-        dsme_log(LOG_ERR, PFIX"failed to chmod %o '%s': %m", (int)mode, HB_SOCKET_PATH);
+        dsme_log(LOG_ERR, PFIX "failed to chmod %o '%s': %m", (int)mode, HB_SOCKET_PATH);
         goto cleanup;
     }
 
     if( listen(listenfd, 5) == -1 ) {
-        dsme_log(LOG_ERR, PFIX"failed to listen client socket: %m");
+        dsme_log(LOG_ERR, PFIX "failed to listen client socket: %m");
         goto cleanup;
     }
 
-    dsme_log(LOG_DEBUG, PFIX"opened client socket %d to %s",
+    dsme_log(LOG_DEBUG, PFIX "opened client socket %d to %s",
 	     listenfd,
 	     HB_SOCKET_PATH);
 
@@ -2854,7 +2854,7 @@ static bool epollfd_add_fd(int fd, void* ptr)
     ev.data.ptr = ptr;
 
     if( epoll_ctl(epollfd, EPOLL_CTL_ADD, fd, &ev) == -1 ) {
-	dsme_log(LOG_ERR, PFIX"failed to add fd=%d to epoll set: %m", fd);
+	dsme_log(LOG_ERR, PFIX "failed to add fd=%d to epoll set: %m", fd);
 	return false;
     }
 
@@ -2868,7 +2868,7 @@ static bool epollfd_add_fd(int fd, void* ptr)
 static void epollfd_remove_fd(int fd)
 {
     if( epoll_ctl(epollfd, EPOLL_CTL_DEL, fd, 0) == -1 ) {
-	dsme_log(LOG_ERR, PFIX"failed to remove fd=%d from epoll set: %m", fd);
+	dsme_log(LOG_ERR, PFIX "failed to remove fd=%d from epoll set: %m", fd);
     }
 }
 
@@ -2886,7 +2886,7 @@ static bool epollfd_handle_client_req(struct epoll_event* event,
     client_t *client       = event->data.ptr;
 
     if( event->events & (EPOLLERR | EPOLLRDHUP | EPOLLHUP) ) {
-        dsme_log(LOG_DEBUG, PFIX"client %s disappeared",
+        dsme_log(LOG_DEBUG, PFIX "client %s disappeared",
                  client->pidtxt);
         goto drop_client_and_fail;
     }
@@ -2894,7 +2894,7 @@ static bool epollfd_handle_client_req(struct epoll_event* event,
     struct _iphb_req_t req = { 0 };
 
     if( recv(client->fd, &req, sizeof req, MSG_WAITALL) <= 0 ) {
-        dsme_log(LOG_ERR, PFIX"failed to read from client %s: %m",
+        dsme_log(LOG_ERR, PFIX "failed to read from client %s: %m",
                  client->pidtxt);
         goto drop_client_and_fail;
     }
@@ -2909,7 +2909,7 @@ static bool epollfd_handle_client_req(struct epoll_event* event,
             break;
 
         default:
-            dsme_log(LOG_ERR, PFIX"client %s gave invalid command 0x%x, drop it",
+            dsme_log(LOG_ERR, PFIX "client %s gave invalid command 0x%x, drop it",
                      client->pidtxt,
                      (unsigned int)req.cmd);
             goto drop_client_and_fail;
@@ -2953,7 +2953,7 @@ static gboolean epollfd_iowatch_cb(GIOChannel*  source,
     /* Abandon watch if we get abnorman conditions from glib */
     if (condition & ~(G_IO_IN | G_IO_PRI))
     {
-	dsme_log(LOG_ERR, PFIX"epoll waiting I/O error reported");
+	dsme_log(LOG_ERR, PFIX "epoll waiting I/O error reported");
 	goto cleanup_nak;
     }
 
@@ -2963,7 +2963,7 @@ static gboolean epollfd_iowatch_cb(GIOChannel*  source,
 	if( errno == EINTR || errno == EAGAIN )
 	    goto cleanup_ack;
 
-        dsme_log(LOG_ERR, PFIX"epoll waiting failed (%m)");
+        dsme_log(LOG_ERR, PFIX "epoll waiting failed (%m)");
 	goto cleanup_nak;
     }
 
@@ -3019,7 +3019,7 @@ cleanup_ack:
 
 cleanup_nak:
     if( !keep_going )
-	dsme_log(LOG_CRIT, PFIX"epoll waiting disabled");
+	dsme_log(LOG_CRIT, PFIX "epoll waiting disabled");
 
     wakelock_unlock(rtc_input);
     modulebase_enter_module(caller);
@@ -3047,7 +3047,7 @@ static bool epollfd_init(void)
     GIOChannel *chan = 0;
 
     if( (epollfd = epoll_create(10)) == -1 ) {
-        dsme_log(LOG_ERR, PFIX"failed to open epoll fd (%m)");
+        dsme_log(LOG_ERR, PFIX "failed to open epoll fd (%m)");
 	goto cleanup;
     }
 
@@ -3083,7 +3083,7 @@ static void systembus_connect(void)
     DBusError err = DBUS_ERROR_INIT;
 
     if( !(systembus = dsme_dbus_get_connection(&err)) ) {
-	dsme_log(LOG_WARNING, PFIX"can't connect to systembus: %s: %s",
+	dsme_log(LOG_WARNING, PFIX "can't connect to systembus: %s: %s",
 		 err.name, err.message);
 	goto cleanup;
     }
@@ -3131,7 +3131,7 @@ DSME_HANDLER(DSM_MSGTYPE_HEARTBEAT, conn, msg)
 {
     struct timeval   tv_now;
 
-    dsme_log(LOG_DEBUG, PFIX"HEARTBEAT from HWWD");
+    dsme_log(LOG_DEBUG, PFIX "HEARTBEAT from HWWD");
     monotime_get_tv(&tv_now);
     clientlist_wakeup_clients_now(&tv_now);
 }
@@ -3139,7 +3139,7 @@ DSME_HANDLER(DSM_MSGTYPE_HEARTBEAT, conn, msg)
 /** Handle WAIT requests from internal clients */
 DSME_HANDLER(DSM_MSGTYPE_WAIT, conn, msg)
 {
-    dsme_log(LOG_DEBUG, PFIX"WAIT req from an internal client");
+    dsme_log(LOG_DEBUG, PFIX "WAIT req from an internal client");
 
     struct timeval   tv_now;
     monotime_get_tv(&tv_now);
@@ -3168,7 +3168,7 @@ DSME_HANDLER(DSM_MSGTYPE_WAIT, conn, msg)
 /** Handle connected to system bus */
 DSME_HANDLER(DSM_MSGTYPE_DBUS_CONNECTED, client, msg)
 {
-    dsme_log(LOG_INFO, PFIX"DBUS_CONNECTED");
+    dsme_log(LOG_INFO, PFIX "DBUS_CONNECTED");
     dsme_dbus_bind_signals(&dbus_signals_bound, dbus_signals_array);
     systembus_connect();
 }
@@ -3176,7 +3176,7 @@ DSME_HANDLER(DSM_MSGTYPE_DBUS_CONNECTED, client, msg)
 /** Handle disconnected from system bus */
 DSME_HANDLER(DSM_MSGTYPE_DBUS_DISCONNECT, client, msg)
 {
-    dsme_log(LOG_INFO, PFIX"DBUS_DISCONNECT");
+    dsme_log(LOG_INFO, PFIX "DBUS_DISCONNECT");
     systembus_disconnect();
 }
 
@@ -3202,7 +3202,7 @@ static time_t get_mtime(const char *path)
 	return st.st_mtime;
 
     if( errno != ENOENT )
-	dsme_log(LOG_ERR, PFIX"%s: failed to get mtime: %m", path);
+	dsme_log(LOG_ERR, PFIX "%s: failed to get mtime: %m", path);
 
     return 0;
 }
@@ -3231,10 +3231,10 @@ static time_t mintime_fetch(void)
     time_t    t_system  = time(0);
     char      tmp[TIMESTAMP_MAX];
 
-    dsme_log(LOG_INFO, PFIX"builtin %s", t_repr(t_builtin, tmp, sizeof tmp));
-    dsme_log(LOG_INFO, PFIX"release %s", t_repr(t_release, tmp, sizeof tmp));
-    dsme_log(LOG_INFO, PFIX"saved   %s", t_repr(t_saved,   tmp, sizeof tmp));
-    dsme_log(LOG_INFO, PFIX"system  %s", t_repr(t_system,  tmp, sizeof tmp));
+    dsme_log(LOG_INFO, PFIX "builtin %s", t_repr(t_builtin, tmp, sizeof tmp));
+    dsme_log(LOG_INFO, PFIX "release %s", t_repr(t_release, tmp, sizeof tmp));
+    dsme_log(LOG_INFO, PFIX "saved   %s", t_repr(t_saved,   tmp, sizeof tmp));
+    dsme_log(LOG_INFO, PFIX "system  %s", t_repr(t_system,  tmp, sizeof tmp));
 
     if( t_saved < t_builtin )
 	t_saved = t_builtin;
@@ -3253,7 +3253,7 @@ static void mintime_store(void)
     static const char *path =  SAVED_TIME_FILE;
     int fd = open(path, O_WRONLY|O_CREAT|O_TRUNC, 0644);
     if( fd == -1 )
-	dsme_log(LOG_ERR, PFIX"%s: failed to open for writing: %m", path);
+	dsme_log(LOG_ERR, PFIX "%s: failed to open for writing: %m", path);
     else
 	close(fd);
 }
@@ -3269,9 +3269,9 @@ static void systemtime_init(void)
     time_t t_min = mintime_fetch();
     time_t t_rtc = rtc_get_time_tm(&tm);
 
-    dsme_log(LOG_INFO, PFIX"min at %s", t_repr(t_min, tmp, sizeof tmp));
-    dsme_log(LOG_INFO, PFIX"rtc at %s", t_repr(t_rtc, tmp, sizeof tmp));
-    dsme_log(LOG_INFO, PFIX"sys at %s", t_repr(t_sys, tmp, sizeof tmp));
+    dsme_log(LOG_INFO, PFIX "min at %s", t_repr(t_min, tmp, sizeof tmp));
+    dsme_log(LOG_INFO, PFIX "rtc at %s", t_repr(t_rtc, tmp, sizeof tmp));
+    dsme_log(LOG_INFO, PFIX "sys at %s", t_repr(t_sys, tmp, sizeof tmp));
 
     /* Take possible cached sys-time vs rtc-time delta into account */
 
@@ -3280,7 +3280,7 @@ static void systemtime_init(void)
     if( delta != 0 ) {
 	/* If we have cached delta time; before accepting it
 	 * check if RTC_SET_TIME actually fails */
-        dsme_log(LOG_INFO, PFIX"rtc to %s", t_repr(t_rtc, tmp, sizeof tmp));
+        dsme_log(LOG_INFO, PFIX "rtc to %s", t_repr(t_rtc, tmp, sizeof tmp));
         if( !rtc_set_time_t(t_rtc) )
             deltatime_is_needed = true;
 	else
@@ -3296,7 +3296,7 @@ static void systemtime_init(void)
 
     if( t_rtc < t_min ) {
         t_rtc = t_min;
-        dsme_log(LOG_INFO, PFIX"rtc to %s", t_repr(t_rtc, tmp, sizeof tmp));
+        dsme_log(LOG_INFO, PFIX "rtc to %s", t_repr(t_rtc, tmp, sizeof tmp));
         if( !rtc_set_time_t(t_rtc) )
             deltatime_is_needed = true;
     }
@@ -3305,10 +3305,10 @@ static void systemtime_init(void)
      * it is ahead of the system time */
 
     if( delta == 0 || t_sys < t_rtc ) {
-        dsme_log(LOG_INFO, PFIX"sys to %s", t_repr(t_rtc, tmp, sizeof tmp));
+        dsme_log(LOG_INFO, PFIX "sys to %s", t_repr(t_rtc, tmp, sizeof tmp));
         struct timeval tv = { .tv_sec = t_rtc, .tv_usec = 0 };
         if( settimeofday(&tv, 0) == -1 )
-            dsme_log(LOG_WARNING, PFIX"failed to set system time");
+            dsme_log(LOG_WARNING, PFIX "failed to set system time");
 
         /* system time should now be within 1 second from rtc time */
     }
@@ -3319,7 +3319,7 @@ static void systemtime_init(void)
      */
 
     if( ioctl(rtc_fd, RTC_UIE_ON, 0) == -1 ) {
-        dsme_log(LOG_WARNING, PFIX"failed to enable update interrupts");
+        dsme_log(LOG_WARNING, PFIX "failed to enable update interrupts");
     }
     else {
         rtc_add_need(RTC_NEED_UPDATES);
@@ -3348,7 +3348,7 @@ void module_init(module_t *handle)
 {
     bool success = false;
 
-    dsme_log(LOG_INFO, PFIX"iphb.so loaded");
+    dsme_log(LOG_INFO, PFIX "iphb.so loaded");
 
     this_module = handle;
 
@@ -3378,26 +3378,26 @@ void module_init(module_t *handle)
      * from dsme too if they are available. */
     if( linux_alarm_init() ) {
 	/* We should get timerfd wakeup even if the device is suspended. */
-        dsme_log(LOG_INFO, PFIX"using timerfd alarm to resume");
+        dsme_log(LOG_INFO, PFIX "using timerfd alarm to resume");
     }
     else if( android_alarm_init() ) {
 	/* On suspend the next to occur alarm device wakeup is programmed
 	 * to rtc. By using the interface from dsme, the wakeup we need
 	 * for iphb purposes should end up considered too. */
-        dsme_log(LOG_NOTICE, PFIX"using android alarm to resume");
+        dsme_log(LOG_NOTICE, PFIX "using android alarm to resume");
     }
     else {
 	/* Assume that nothing interferes with rtc ioctl + read. */
-        dsme_log(LOG_NOTICE, PFIX"using rtc alarm to resume");
+        dsme_log(LOG_NOTICE, PFIX "using rtc alarm to resume");
     }
 
     success = true;
 
 cleanup:
     if( success )
-        dsme_log(LOG_INFO, PFIX"iphb started");
+        dsme_log(LOG_INFO, PFIX "iphb started");
     else
-	dsme_log(LOG_ERR, PFIX"iphb not started");
+	dsme_log(LOG_ERR, PFIX "iphb not started");
 
     return;
 }
@@ -3418,9 +3418,9 @@ void module_fini(void)
     /* store system time to rtc */
     struct timeval tv_sys, tv_rtc;
     if( !rtc_get_time_tv(&tv_rtc) )
-	dsme_log(LOG_ERR, PFIX"could not get rtc time");
+	dsme_log(LOG_ERR, PFIX "could not get rtc time");
     else if( !realtime_get_tv(&tv_sys) )
-	dsme_log(LOG_ERR, PFIX"could not get system time");
+	dsme_log(LOG_ERR, PFIX "could not get system time");
     else {
 	struct timeval t;
 	timersub(&tv_sys, &tv_rtc, &t);
@@ -3430,11 +3430,11 @@ void module_fini(void)
 	 */
 
 	if( !t.tv_sec )
-	    dsme_log(LOG_CRIT, PFIX"RTC in sync with system time");
+	    dsme_log(LOG_CRIT, PFIX "RTC in sync with system time");
 	else if( !rtc_set_time_tv(&tv_sys) )
-	    dsme_log(LOG_ERR, PFIX"could not set rtc time");
+	    dsme_log(LOG_ERR, PFIX "could not set rtc time");
 	else
-	    dsme_log(LOG_CRIT, PFIX"RTC updated to system time");
+	    dsme_log(LOG_CRIT, PFIX "RTC updated to system time");
     }
 
     /* save last-known-system-time */
@@ -3465,5 +3465,5 @@ void module_fini(void)
     wakelock_unlock(rtc_wakeup);
     wakelock_unlock(rtc_input);
 
-    dsme_log(LOG_INFO, PFIX"iphb.so unloaded");
+    dsme_log(LOG_INFO, PFIX "iphb.so unloaded");
 }

--- a/modules/malf.c
+++ b/modules/malf.c
@@ -34,6 +34,8 @@
 #include <unistd.h>
 #include <sys/wait.h>
 
+#define PFIX "malf: "
+
 static const char* const malf_reason_name[] = {
     "SOFTWARE",
     "HARDWARE",
@@ -50,8 +52,7 @@ static bool enter_malf(DSME_MALF_REASON reason,
         reason = DSME_MALF_SOFTWARE;
     }
 
-    dsme_log(LOG_INFO,
-             "enter_malf '%s' '%s' '%s'",
+    dsme_log(LOG_INFO, PFIX "enter_malf '%s' '%s' '%s'",
              malf_reason_name[reason],
              component ? component : "(no component)",
              details ? details : "(no details)");
@@ -67,13 +68,13 @@ static bool enter_malf(DSME_MALF_REASON reason,
         0
     };
     if ((pid = fork()) < 0) {
-        dsme_log(LOG_CRIT, "fork failed, exiting");
+        dsme_log(LOG_CRIT, PFIX "fork failed, exiting");
         dsme_main_loop_quit(EXIT_FAILURE);
         return false;
     } else if (pid == 0) {
         execv("/usr/sbin/enter_malf", args);
 
-        dsme_log(LOG_CRIT, "entering MALF failed");
+        dsme_log(LOG_CRIT, PFIX "entering MALF failed");
         return false;
     }
 
@@ -81,11 +82,11 @@ static bool enter_malf(DSME_MALF_REASON reason,
         if (rc < 0 && errno == ECHILD)
             break;
     if (rc != pid || WEXITSTATUS(status) != 0) {
-        dsme_log(LOG_CRIT, "enter_malf return value != 0, entering MALF failed");
+        dsme_log(LOG_CRIT, PFIX "enter_malf return value != 0, entering MALF failed");
         return false;
     }
 
-    dsme_log(LOG_CRIT, "entering MALF state");
+    dsme_log(LOG_CRIT, PFIX "entering MALF state");
     return true;
 }
 
@@ -112,10 +113,10 @@ module_fn_info_t message_handlers[] = {
 
 void module_init(module_t* module)
 {
-    dsme_log(LOG_DEBUG, "malf.so loaded");
+    dsme_log(LOG_DEBUG, PFIX "malf.so loaded");
 }
 
 void module_fini(void)
 {
-    dsme_log(LOG_DEBUG, "malf.so unloaded");
+    dsme_log(LOG_DEBUG, PFIX "malf.so unloaded");
 }

--- a/modules/malf.c
+++ b/modules/malf.c
@@ -34,7 +34,6 @@
 #include <unistd.h>
 #include <sys/wait.h>
 
-
 static const char* const malf_reason_name[] = {
     "SOFTWARE",
     "HARDWARE",

--- a/modules/malf.h
+++ b/modules/malf.h
@@ -27,7 +27,6 @@
 
 #include <dsme/messages.h>
 
-
 typedef enum {
     DSME_MALF_SOFTWARE,
     DSME_MALF_HARDWARE,

--- a/modules/powerontimer.c
+++ b/modules/powerontimer.c
@@ -52,7 +52,7 @@
 #include "powerontimer_backend.h"
 
 // prefix for log messages from this module
-#define LOGPFIX "poweron-timer: "
+#define PFIX "poweron-timer: "
 
 static bool      in_user_mode = false;
 

--- a/modules/powerontimer_backend.c
+++ b/modules/powerontimer_backend.c
@@ -62,7 +62,6 @@ typedef struct
                     * Initialize to zero.
                     * Actual value set by pot_import_cal_data().
                     */
-
 } pot_cal_data_v0;
 
 // cal block v1 -> data contained in v1
@@ -76,7 +75,6 @@ typedef struct
   int32_t reboots; // number of reboots detected via uptime drops
 
   int32_t updates; // number of times the cal block has been written
-
 } pot_cal_data_v1;
 
 // cal block version currently expected by the logic
@@ -131,7 +129,6 @@ static void uptime_read(struct timeval *tv)
   }
 
 cleanup:
-
   if( file != 0 ) fclose(file);
 
   tv->tv_sec  = (time_t)secs;
@@ -229,7 +226,6 @@ static int pot_import_cal_data(pot_cal_data *pot,
    */
 
 cleanup:
-
   // mark current version
   pot->version = 1;
 
@@ -263,7 +259,6 @@ static int pot_read_cal(pot_cal_data *pot)
   err = pot_import_cal_data(pot, data, size);
 
 cleanup:
-
   if( cal != 0 ) cal_finish(cal);
   free(data);
   return err;
@@ -293,7 +288,6 @@ static int pot_write_cal(const pot_cal_data *pot)
   err = 0;
 
 cleanup:
-
   if( cal != 0 ) cal_finish(cal);
 
   return err;

--- a/modules/powerontimer_backend.c
+++ b/modules/powerontimer_backend.c
@@ -43,7 +43,7 @@
  * ========================================================================= */
 
 // prefix for log messages from this module
-#define LOGPFIX "poweron-timer: "
+#define PFIX "poweron-timer: "
 
 /* ========================================================================= *
  * CAL block contents
@@ -93,7 +93,7 @@ static void monotime_get(struct timeval *tv)
   struct timespec ts = { 0, 0 };
   if( clock_gettime(CLOCK_MONOTONIC, &ts) == -1 )
   {
-    dsme_log(LOG_WARNING, LOGPFIX"%s: %s", "CLOCK_MONOTONIC", strerror(errno));
+    dsme_log(LOG_WARNING, PFIX "%s: %s", "CLOCK_MONOTONIC", strerror(errno));
   }
   TIMESPEC_TO_TIMEVAL(tv, &ts);
 }
@@ -113,19 +113,19 @@ static void uptime_read(struct timeval *tv)
 
   if( (file = fopen(path, "r")) == 0 )
   {
-    dsme_log(LOG_WARNING, LOGPFIX"%s: %s", path, strerror(errno));
+    dsme_log(LOG_WARNING, PFIX "%s: %s", path, strerror(errno));
     goto cleanup;
   }
 
   if( fgets(data, sizeof data, file ) == 0 )
   {
-    dsme_log(LOG_WARNING, LOGPFIX"%s: %s", path, "unexpected EOF");
+    dsme_log(LOG_WARNING, PFIX "%s: %s", path, "unexpected EOF");
     goto cleanup;
   }
 
   if( (secs = strtod(data, 0)) <= 0.0 )
   {
-    dsme_log(LOG_WARNING, LOGPFIX"%s: %s", path, "parsed non-positive uptime");
+    dsme_log(LOG_WARNING, PFIX "%s: %s", path, "parsed non-positive uptime");
   }
 
 cleanup:
@@ -192,7 +192,7 @@ static int pot_import_cal_data(pot_cal_data *pot,
   // import based on block version
   if( size < sizeof *v0 )
   {
-    dsme_log(LOG_ERR, LOGPFIX"data block too small");
+    dsme_log(LOG_ERR, PFIX "data block too small");
     goto cleanup;
   }
 
@@ -201,7 +201,7 @@ static int pot_import_cal_data(pot_cal_data *pot,
   case 1:
     if( size < sizeof *v1 )
     {
-      dsme_log(LOG_ERR, LOGPFIX"data block (v%"PRId32") %s",
+      dsme_log(LOG_ERR, PFIX "data block (v%"PRId32") %s",
                v0->version, "too small");
       goto cleanup;
     }
@@ -213,7 +213,7 @@ static int pot_import_cal_data(pot_cal_data *pot,
     break;
 
   default:
-    dsme_log(LOG_ERR, LOGPFIX"data block (v%"PRId32") %s",
+    dsme_log(LOG_ERR, PFIX "data block (v%"PRId32") %s",
              v0->version, "unkown");
     goto cleanup;
   }
@@ -221,7 +221,7 @@ static int pot_import_cal_data(pot_cal_data *pot,
   // no errors
   err = 0;
 
-  /* dsme_log(LOG_INFO, LOGPFIX"data block (v%"PRId32") %s",
+  /* dsme_log(LOG_INFO, PFIX "data block (v%"PRId32") %s",
    *        v0->version, "imported");
    */
 
@@ -245,14 +245,14 @@ static int pot_read_cal(pot_cal_data *pot)
 
   if( cal_init(&cal) < 0 )
   {
-    dsme_log(LOG_ERR, LOGPFIX"cal %s failed", "init");
+    dsme_log(LOG_ERR, PFIX "cal %s failed", "init");
     goto cleanup;
   }
 
   if( cal_read_block(cal, pot_cal_name, &data, &size, pot_cal_flags) < 0 )
   {
     // just a warning as it will be missing on the first boot
-    dsme_log(LOG_WARNING, LOGPFIX"cal %s failed", "read");
+    dsme_log(LOG_WARNING, PFIX "cal %s failed", "read");
     goto cleanup;
   }
 
@@ -275,13 +275,13 @@ static int pot_write_cal(const pot_cal_data *pot)
 
   if( cal_init(&cal) < 0 )
   {
-    dsme_log(LOG_ERR, LOGPFIX"cal %s failed", "init");
+    dsme_log(LOG_ERR, PFIX "cal %s failed", "init");
     goto cleanup;
   }
 
   if( cal_write_block(cal, pot_cal_name, pot, sizeof *pot, pot_cal_flags) < 0 )
   {
-    dsme_log(LOG_ERR, LOGPFIX"cal %s failed", "write");
+    dsme_log(LOG_ERR, PFIX "cal %s failed", "write");
     goto cleanup;
   }
 

--- a/modules/processwd.c
+++ b/modules/processwd.c
@@ -54,6 +54,8 @@
 #include <sys/types.h>
 #include <signal.h>
 
+#define PFIX "processwd: "
+
 /**
  * @ingroup processwd
  * Defines how may pings need to be ignored before the process is killed.
@@ -83,7 +85,7 @@ static dsme_swwd_entry_t* swwd_entry_new(pid_t pid, endpoint_t* client)
   dsme_swwd_entry_t* proc =
     (dsme_swwd_entry_t*)malloc(sizeof(dsme_swwd_entry_t));
   if (proc == NULL) {
-      dsme_log(LOG_CRIT, "%s", strerror(errno));
+      dsme_log(LOG_CRIT, PFIX "%s", strerror(errno));
   } else {
       proc->pid        = pid;
       proc->pingcount  = 0;
@@ -100,7 +102,7 @@ static void swwd_entry_delete(dsme_swwd_entry_t * proc)
   if (proc) {
       if (proc->kill_timer) {
           dsme_destroy_timer(proc->kill_timer);
-          dsme_log(LOG_NOTICE, "killing process (pid: %i)", proc->pid);
+          dsme_log(LOG_NOTICE, PFIX "killing process (pid: %i)", proc->pid);
           kill(proc->pid, SIGKILL);
       }
       endpoint_free(proc->client);
@@ -137,7 +139,7 @@ static int abort_timeout_func(void* data)
 
       proc->kill_timer = 0; /* the timer has expired */
 
-      dsme_log(LOG_NOTICE, "killing process (pid: %i)", pid);
+      dsme_log(LOG_NOTICE, PFIX "killing process (pid: %i)", pid);
       kill(pid, SIGKILL);
 
       swwd_entry_delete(proc);
@@ -149,7 +151,7 @@ static int abort_timeout_func(void* data)
 
 DSME_HANDLER(DSM_MSGTYPE_WAKEUP, conn, msg)
 {
-    dsme_log(LOG_DEBUG, "processwd: ping");
+    dsme_log(LOG_DEBUG, PFIX "processwd: ping");
     ping_all();
 
     subscribe_to_wakeup();
@@ -171,7 +173,7 @@ static void ping_all(void)
         /* Is it pinged too many times ? */
         if (proc->pingcount == MAXPING) {
             if (proc->kill_timer == 0) {
-                dsme_log(LOG_ERR, "process (pid: %i) not responding to processwd pings,"
+                dsme_log(LOG_ERR, PFIX "process (pid: %i) not responding to processwd pings,"
                          " aborting it...", proc->pid);
                 /* give the nonresponsive process chance to abort... */
                 kill(proc->pid, SIGABRT);
@@ -183,7 +185,7 @@ static void ping_all(void)
                                               GINT_TO_POINTER(proc->pid));
                 if (proc->kill_timer == 0) {
                     /* timer creation failed; kill the process immediately */
-                    dsme_log(LOG_ERR, "...kill due to timer failure: %s", strerror(errno));
+                    dsme_log(LOG_ERR, PFIX "...kill due to timer failure: %s", strerror(errno));
                     kill(proc->pid, SIGKILL);
 
                     swwd_entry_delete(proc);
@@ -196,7 +198,7 @@ static void ping_all(void)
 
             msg.pid = proc->pid;
             endpoint_send(proc->client, &msg);
-            dsme_log(LOG_DEBUG, "sent ping to pid %i", proc->pid);
+            dsme_log(LOG_DEBUG, PFIX "sent ping to pid %i", proc->pid);
         }
     }
 }
@@ -221,7 +223,7 @@ DSME_HANDLER(DSM_MSGTYPE_PROCESSWD_CREATE, client, msg)
 
   if (g_slist_find_custom(processes, GINT_TO_POINTER(msg->pid), compare_pids)) {
       /* Already there - just ignore and return */
-      dsme_log(LOG_DEBUG, "Process WD requested for existing pid");
+      dsme_log(LOG_DEBUG, PFIX "Process WD requested for existing pid");
       return;
   }
 
@@ -232,7 +234,7 @@ DSME_HANDLER(DSM_MSGTYPE_PROCESSWD_CREATE, client, msg)
 
   processes = g_slist_prepend(processes, proc);
 
-  dsme_log(LOG_DEBUG, "Added process (pid: %i) to processwd", proc->pid);
+  dsme_log(LOG_DEBUG, PFIX "Added process (pid: %i) to processwd", proc->pid);
 }
 
 /**
@@ -246,14 +248,13 @@ DSME_HANDLER(DSM_MSGTYPE_PROCESSWD_PONG, conn, msg)
   node = g_slist_find_custom(processes, GINT_TO_POINTER(msg->pid), compare_pids);
   if (!node) {
       /* Already there - just ignore and return */
-      dsme_log(LOG_WARNING, "ProcessWD PONG for non-existing pid %i", msg->pid);
+      dsme_log(LOG_WARNING, PFIX "ProcessWD PONG for non-existing pid %i", msg->pid);
       return;
   }
 
   proc = (dsme_swwd_entry_t *)(node->data);
   if (proc) {
-      dsme_log(LOG_DEBUG,
-               "pong for pid %i after %d ping(s)",
+      dsme_log(LOG_DEBUG, PFIX "pong for pid %i after %d ping(s)",
                msg->pid,
                proc->pingcount);
       proc->pingcount = 0;
@@ -270,8 +271,7 @@ static void swwd_del(pid_t pid)
 
   node = g_slist_find_custom(processes, GINT_TO_POINTER(pid), compare_pids);
   if (!node) {
-      dsme_log(LOG_DEBUG,
-               "no process registered to use processwd with pid %i",
+      dsme_log(LOG_DEBUG, PFIX "no process registered to use processwd with pid %i",
                pid);
       /* Nothing to delete - just ignore and return */
       return;
@@ -280,7 +280,7 @@ static void swwd_del(pid_t pid)
   proc = (dsme_swwd_entry_t*)(node->data);
   swwd_entry_delete(proc);
   processes = g_slist_delete_link(processes, node);
-  dsme_log(LOG_DEBUG, "removed exited process (pid %d) from process wd", pid);
+  dsme_log(LOG_DEBUG, PFIX "removed exited process (pid %d) from process wd", pid);
 }
 
 DSME_HANDLER(DSM_MSGTYPE_PROCESSWD_DELETE, conn, msg)
@@ -301,14 +301,14 @@ DSME_HANDLER(DSM_MSGTYPE_CLOSE, conn, msg)
   while ((node = g_slist_find_custom(node, conn, compare_endpoints))) {
       if (node->data) {
           proc = (dsme_swwd_entry_t *)(node->data);
-          dsme_log(LOG_DEBUG, "process socket closed, killing process with pid %i", proc->pid);
+          dsme_log(LOG_DEBUG, PFIX "process socket closed, killing process with pid %i", proc->pid);
           kill(proc->pid, SIGKILL);
           swwd_entry_delete(proc);
       }
       deleted = node;
       node = g_slist_next(node);
       processes = g_slist_delete_link(processes, deleted);
-      dsme_log(LOG_DEBUG, "removed process with closed socket from process wd");
+      dsme_log(LOG_DEBUG, PFIX "removed process with closed socket from process wd");
   }
 }
 
@@ -333,7 +333,7 @@ module_fn_info_t message_handlers[] = {
 
 void module_init(module_t *handle)
 {
-  dsme_log(LOG_DEBUG, "processwd.so loaded");
+  dsme_log(LOG_DEBUG, PFIX "processwd.so loaded");
 
   subscribe_to_wakeup();
 }
@@ -348,5 +348,5 @@ void module_fini(void)
 
   // TODO: cancel wakeup subscription
 
-  dsme_log(LOG_DEBUG, "processwd.so unloaded");
+  dsme_log(LOG_DEBUG, PFIX "processwd.so unloaded");
 }

--- a/modules/processwd.c
+++ b/modules/processwd.c
@@ -28,13 +28,12 @@
    License along with Dsme.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 /**
  * @defgroup modules DSME Modules
  */
 
 /**
- * @defgroup processwd Process watchdog 
+ * @defgroup processwd Process watchdog
  * @ingroup modules
  *
  */
@@ -55,7 +54,6 @@
 #include <sys/types.h>
 #include <signal.h>
 
-
 /**
  * @ingroup processwd
  * Defines how may pings need to be ignored before the process is killed.
@@ -68,10 +66,8 @@
  */
 #define ABORT_GRACE_PERIOD_SECONDS 2
 
-
 static void ping_all(void);
 static void subscribe_to_wakeup(void);
-
 
 typedef struct {
     pid_t        pid;
@@ -80,9 +76,7 @@ typedef struct {
     dsme_timer_t kill_timer;
 } dsme_swwd_entry_t;
 
-
 static GSList* processes = 0;
-
 
 static dsme_swwd_entry_t* swwd_entry_new(pid_t pid, endpoint_t* client)
 {
@@ -107,7 +101,7 @@ static void swwd_entry_delete(dsme_swwd_entry_t * proc)
       if (proc->kill_timer) {
           dsme_destroy_timer(proc->kill_timer);
           dsme_log(LOG_NOTICE, "killing process (pid: %i)", proc->pid);
-          kill(proc->pid, SIGKILL); 
+          kill(proc->pid, SIGKILL);
       }
       endpoint_free(proc->client);
       free(proc);
@@ -131,7 +125,6 @@ static gint compare_endpoints(gconstpointer proc, gconstpointer client)
   return !endpoint_same(((dsme_swwd_entry_t*)proc)->client, client);
 }
 
-
 static int abort_timeout_func(void* data)
 {
   GSList* node;
@@ -145,7 +138,7 @@ static int abort_timeout_func(void* data)
       proc->kill_timer = 0; /* the timer has expired */
 
       dsme_log(LOG_NOTICE, "killing process (pid: %i)", pid);
-      kill(pid, SIGKILL); 
+      kill(pid, SIGKILL);
 
       swwd_entry_delete(proc);
       processes = g_slist_delete_link(processes, node);
@@ -178,7 +171,7 @@ static void ping_all(void)
         /* Is it pinged too many times ? */
         if (proc->pingcount == MAXPING) {
             if (proc->kill_timer == 0) {
-                dsme_log(LOG_ERR, "process (pid: %i) not responding to processwd pings," 
+                dsme_log(LOG_ERR, "process (pid: %i) not responding to processwd pings,"
                          " aborting it...", proc->pid);
                 /* give the nonresponsive process chance to abort... */
                 kill(proc->pid, SIGABRT);
@@ -296,7 +289,7 @@ DSME_HANDLER(DSM_MSGTYPE_PROCESSWD_DELETE, conn, msg)
 }
 
 /**
- * 	If socket closed remove it from checking list 
+ * 	If socket closed remove it from checking list
  */
 DSME_HANDLER(DSM_MSGTYPE_CLOSE, conn, msg)
 {
@@ -328,7 +321,7 @@ DSME_HANDLER(DSM_MSGTYPE_CLOSE, conn, msg)
  *   event. dsmemsg_swwd_t
  * - DSM_MSGTYPE_PONG The reply sent by a process for ping. dsmemsg_swwd_t
  *   dsmemsg_timeout_change_t
- */ 
+ */
 module_fn_info_t message_handlers[] = {
       DSME_HANDLER_BINDING(DSM_MSGTYPE_PROCESSWD_CREATE),
       DSME_HANDLER_BINDING(DSM_MSGTYPE_PROCESSWD_DELETE),

--- a/modules/pwrkeymonitor.c
+++ b/modules/pwrkeymonitor.c
@@ -97,14 +97,14 @@ pwrkey_trigger(void *data)
     /* No shutdown via powerkey while in update mode */
     if( pwrkey_update_mode_is_active() )
     {
-        dsme_log(LOG_WARNING, PFIX"ongoing os update; ignoring power key");
+        dsme_log(LOG_WARNING, PFIX "ongoing os update; ignoring power key");
         // TODO: send a dbus signal (TBD) so that ui side can warn the
         //       user before some hw specific immediate power off gets
         //       triggered if power key is kept pressed any longer
         return FALSE;
     }
 
-    dsme_log(LOG_CRIT, PFIX"Timer triggered, initiating shutdown");
+    dsme_log(LOG_CRIT, PFIX "Timer triggered, initiating shutdown");
 
 #ifdef PWRKEY_SHUTDOWN_MSG_TELINIT
     /* Use telinit message */
@@ -134,17 +134,17 @@ start_pwrkey_timer(void)
 {
     if( pwrkey_timer )
     {
-        dsme_log(LOG_DEBUG, PFIX"Timer already running");
+        dsme_log(LOG_DEBUG, PFIX "Timer already running");
     }
     else if( !(pwrkey_timer = dsme_create_timer_seconds(PWRKEY_TIMER_SECONDS,
                                                         pwrkey_trigger,
                                                         NULL)) )
     {
-        dsme_log(LOG_CRIT, PFIX"Timer creation failed!");
+        dsme_log(LOG_CRIT, PFIX "Timer creation failed!");
     }
     else
     {
-        dsme_log(LOG_DEBUG, PFIX"Timer started (%d sec to shutdown)",
+        dsme_log(LOG_DEBUG, PFIX "Timer started (%d sec to shutdown)",
                  PWRKEY_TIMER_SECONDS);
     }
 }
@@ -158,7 +158,7 @@ stop_pwrkey_timer(void)
     {
         dsme_destroy_timer(pwrkey_timer);
         pwrkey_timer = 0;
-        dsme_log(LOG_DEBUG, PFIX"Timer stopped");
+        dsme_log(LOG_DEBUG, PFIX "Timer stopped");
     }
 }
 
@@ -194,20 +194,20 @@ emits_powerkey_events(int fd)
     /* Get bitmask of supported event types */
     if( ioctl(fd, EVIOCGBIT(0, EV_CNT), mask_eve) == -1 )
     {
-        dsme_log(LOG_DEBUG, PFIX"EVIOCGBIT(%d): %m", fd);
+        dsme_log(LOG_DEBUG, PFIX "EVIOCGBIT(%d): %m", fd);
         goto EXIT;
     }
 
     /* Get bitmask of supported key event codes */
     if( mask_eve[EVDEVBITS_OFFS(EV_KEY)] & EVDEVBITS_MASK(EV_KEY) ) {
         if( ioctl(fd, EVIOCGBIT(EV_KEY, KEY_CNT), mask_key) == -1 )
-            dsme_log(LOG_DEBUG, PFIX"EVIOCGBIT(%d): %m", fd);
+            dsme_log(LOG_DEBUG, PFIX "EVIOCGBIT(%d): %m", fd);
     }
 
     /* Get bitmask of supported abs event codes */
     if( mask_eve[EVDEVBITS_OFFS(EV_ABS)] & EVDEVBITS_MASK(EV_ABS) ) {
         if( ioctl(fd, EVIOCGBIT(EV_ABS, ABS_CNT), mask_abs) == -1 )
-            dsme_log(LOG_DEBUG, PFIX"EVIOCGBIT(%d): %m", fd);
+            dsme_log(LOG_DEBUG, PFIX "EVIOCGBIT(%d): %m", fd);
     }
 
     /* Require: KEY_POWER events are emitted */
@@ -352,7 +352,7 @@ process_kbevent(GIOChannel* chan, GIOCondition condition, gpointer data)
     /* Abandon watch if we get abnorman conditions from glib */
     if (condition & ~(G_IO_IN | G_IO_PRI))
     {
-        dsme_log(LOG_ERR, PFIX"I/O error");
+        dsme_log(LOG_ERR, PFIX "I/O error");
         keep_going = FALSE;
     }
 
@@ -368,27 +368,27 @@ process_kbevent(GIOChannel* chan, GIOCondition condition, gpointer data)
         case EAGAIN:
             break;
         default:
-            dsme_log(LOG_ERR, PFIX"read: %m");
+            dsme_log(LOG_ERR, PFIX "read: %m");
             keep_going = FALSE;
             break;
         }
     }
     else if( rc == 0 )
     {
-        dsme_log(LOG_ERR, PFIX"read: EOF");
+        dsme_log(LOG_ERR, PFIX "read: EOF");
         keep_going = FALSE;
     }
     else
     {
         int n = rc / sizeof *buf;
 
-        dsme_log(LOG_DEBUG, PFIX"Processing %d events", n);
+        dsme_log(LOG_DEBUG, PFIX "Processing %d events", n);
 
         for( int i = 0; i < n; ++i )
         {
             const struct input_event *eve = buf + i;
 
-            dsme_log(LOG_DEBUG, PFIX"Got event, type: %d code: %d value: %d",
+            dsme_log(LOG_DEBUG, PFIX "Got event, type: %d code: %d value: %d",
                      eve->type, eve->code, eve->value);
 
             if( eve->type == EV_KEY && eve->code == KEY_POWER )
@@ -410,7 +410,7 @@ process_kbevent(GIOChannel* chan, GIOCondition condition, gpointer data)
 
     if( !keep_going )
     {
-        dsme_log(LOG_WARNING, PFIX"disabling io watch");
+        dsme_log(LOG_WARNING, PFIX "disabling io watch");
 
         /* the watch gets removed as we return FALSE, but
          * the channel must be removed from tracking list */
@@ -442,19 +442,19 @@ probe_evdev_device(const char *path)
 
     if( (file = open(path, O_RDONLY)) == -1 )
     {
-        dsme_log(LOG_ERR, PFIX"%s: open: %m", path);
+        dsme_log(LOG_ERR, PFIX "%s: open: %m", path);
         goto EXIT;
     }
 
     if( !emits_powerkey_events(file) )
     {
-        dsme_log(LOG_DEBUG, PFIX"%s: not a powerkey device", path);
+        dsme_log(LOG_DEBUG, PFIX "%s: not a powerkey device", path);
         goto EXIT;
     }
 
     if( !(chan = g_io_channel_unix_new(file)) )
     {
-        dsme_log(LOG_ERR, PFIX"%s: io channel setup failed", path);
+        dsme_log(LOG_ERR, PFIX "%s: io channel setup failed", path);
         goto EXIT;
     }
 
@@ -464,11 +464,11 @@ probe_evdev_device(const char *path)
     /* Set to NULL encoding so that we can turn off the buffering */
     if( g_io_channel_set_encoding(chan, NULL, &err) != G_IO_STATUS_NORMAL )
     {
-        dsme_log(LOG_WARNING, PFIX"%s: unable to set io channel encoding",
+        dsme_log(LOG_WARNING, PFIX "%s: unable to set io channel encoding",
                  path);
         if( err )
         {
-             dsme_log(LOG_WARNING, PFIX"%s", err->message);
+             dsme_log(LOG_WARNING, PFIX "%s", err->message);
         }
         // continue anyway
     }
@@ -478,11 +478,11 @@ probe_evdev_device(const char *path)
 				 G_IO_IN | G_IO_ERR | G_IO_HUP | G_IO_NVAL,
 				 process_kbevent, 0)) )
     {
-        dsme_log(LOG_ERR, PFIX"%s: unable to add io channel watch", path);
+        dsme_log(LOG_ERR, PFIX "%s: unable to add io channel watch", path);
         goto EXIT;
     }
 
-    dsme_log(LOG_DEBUG, PFIX"%s: channel=%p, watch=%u", path, chan, watch);
+    dsme_log(LOG_DEBUG, PFIX "%s: channel=%p, watch=%u", path, chan, watch);
 
     /* watchlist owns the channel and watch */
     watchlist_add(chan, watch), chan = 0, watch = 0;
@@ -514,7 +514,7 @@ start_pwrkey_monitor(void)
 
     if( !(dir = opendir(base)) )
     {
-        dsme_log(LOG_ERR, PFIX"opendir(%s): %m", base);
+        dsme_log(LOG_ERR, PFIX "opendir(%s): %m", base);
         goto EXIT;
     }
 
@@ -543,7 +543,7 @@ EXIT:
 
     if( cnt < 1 )
     {
-        dsme_log(LOG_WARNING, PFIX"could not find any powerkey input devices");
+        dsme_log(LOG_WARNING, PFIX "could not find any powerkey input devices");
     }
 
     return cnt > 0;
@@ -565,12 +565,12 @@ module_init(module_t * handle)
 
     start_pwrkey_monitor();
 
-    dsme_log(LOG_DEBUG, "libpwrkeymonitor.so loaded");
+    dsme_log(LOG_DEBUG, PFIX "libpwrkeymonitor.so loaded");
 }
 
 void
 module_fini(void)
 {
     stop_pwrkey_monitor();
-    dsme_log(LOG_DEBUG, "libpwrkeymonitor.so unloaded");
+    dsme_log(LOG_DEBUG, PFIX "libpwrkeymonitor.so unloaded");
 }

--- a/modules/pwrkeymonitor.c
+++ b/modules/pwrkeymonitor.c
@@ -230,7 +230,6 @@ typedef struct
 {
     GIOChannel *chan;
     guint       watch;
-
 } channel_watch_t;
 
 /** Allocate and initialize an io channel watch structure
@@ -540,7 +539,6 @@ start_pwrkey_monitor(void)
     }
 
 EXIT:
-
     if( dir ) closedir(dir);
 
     if( cnt < 1 )

--- a/modules/runlevel.c
+++ b/modules/runlevel.c
@@ -224,7 +224,6 @@ static void shutdown(dsme_runlevel_t runlevel)
               }
           }
       }
-
   }
 
   return;
@@ -300,7 +299,6 @@ static bool remount_mmc_readonly(void)
 
       dsme_log(LOG_NOTICE, "MMC remounted read-only");
       return true;
-
   } else {
       dsme_log(LOG_NOTICE, "MMC not mounted");
       return true;

--- a/modules/runlevel.c
+++ b/modules/runlevel.c
@@ -39,6 +39,8 @@
 #include <unistd.h>
 #include <sys/wait.h>
 
+#define PFIX "runlevel: "
+
 static bool change_runlevel(dsme_runlevel_t runlevel);
 static bool remount_mmc_readonly(void);
 
@@ -66,7 +68,7 @@ system_wrapper(const char *command)
     char        trapped[32] = "";
     const char *dumped      = "";
 
-    dsme_log(LOG_NOTICE, "Executing: %s", command);
+    dsme_log(LOG_NOTICE, PFIX "Executing: %s", command);
 
     if( (status = system(command)) == -1 ) {
         snprintf(exited, sizeof exited, " exec=failed");
@@ -88,7 +90,7 @@ system_wrapper(const char *command)
         }
     }
 
-    dsme_log(LOG_NOTICE, "Executed:  %s -%s%s%s result=%d",
+    dsme_log(LOG_NOTICE, PFIX "Executed:  %s -%s%s%s result=%d",
              command, exited, trapped, dumped, result);
 
     return result;
@@ -115,7 +117,7 @@ locate_systemctl_binary(void)
             break;
     }
 
-    dsme_log(LOG_DEBUG, "systemctl binary = %s", path ?: "unknown");
+    dsme_log(LOG_DEBUG, PFIX "systemctl binary = %s", path ?: "unknown");
     return path;
 }
 
@@ -138,7 +140,7 @@ static bool change_runlevel(dsme_runlevel_t runlevel)
       return false;
   }
   if (system_wrapper(command) != 0) {
-      dsme_log(LOG_CRIT, "failed to change runlevel, trying again in 2s");
+      dsme_log(LOG_CRIT, PFIX "failed to change runlevel, trying again in 2s");
       sleep(2);
       return system_wrapper(command) == 0;
   }
@@ -161,10 +163,10 @@ static void shutdown(dsme_runlevel_t runlevel)
       (runlevel != DSME_RUNLEVEL_SHUTDOWN) &&
       (runlevel != DSME_RUNLEVEL_MALF))
   {
-      dsme_log(LOG_WARNING, "Shutdown request to bad runlevel (%d)", runlevel);
+      dsme_log(LOG_WARNING, PFIX "Shutdown request to bad runlevel (%d)", runlevel);
       return;
   }
-  dsme_log(LOG_NOTICE,
+  dsme_log(LOG_NOTICE, PFIX "%s",
            runlevel == DSME_RUNLEVEL_SHUTDOWN ? "Shutdown" :
            runlevel == DSME_RUNLEVEL_REBOOT   ? "Reboot"   :
                                                 "Malf");
@@ -177,18 +179,18 @@ static void shutdown(dsme_runlevel_t runlevel)
       } else if (runlevel == DSME_RUNLEVEL_REBOOT) {
           snprintf(command, sizeof command, "%s --no-block reboot", systemctl);
       } else {
-          dsme_log(LOG_WARNING, "MALF not supported by our systemd implementation");
+          dsme_log(LOG_WARNING, PFIX "MALF not supported by our systemd implementation");
           goto fail_and_exit;
       }
       if (system_wrapper(command) != 0) {
-          dsme_log(LOG_WARNING, "command %s failed: %m", command);
+          dsme_log(LOG_WARNING, PFIX "command %s failed: %m", command);
           /* We ignore error. No retry or anything else */
       }
   }
   /* If runlevel change fails, handle the shutdown/reboot by DSME */
   else if (!change_runlevel(runlevel))
   {
-      dsme_log(LOG_CRIT, "Doing forced shutdown/reboot");
+      dsme_log(LOG_CRIT, PFIX "Doing forced shutdown/reboot");
       sync();
 
       (void)remount_mmc_readonly();
@@ -202,10 +204,10 @@ static void shutdown(dsme_runlevel_t runlevel)
               snprintf(command, sizeof(command), "/usr/sbin/poweroff");
           }
           if (system_wrapper(command) != 0) {
-              dsme_log(LOG_ERR, "%s failed, trying again in 3s", command);
+              dsme_log(LOG_ERR, PFIX "%s failed, trying again in 3s", command);
               sleep(3);
               if (system_wrapper(command) != 0) {
-                  dsme_log(LOG_ERR, "%s failed again", command);
+                  dsme_log(LOG_ERR, PFIX "%s failed again", command);
                   goto fail_and_exit;
               }
           }
@@ -216,10 +218,10 @@ static void shutdown(dsme_runlevel_t runlevel)
               snprintf(command, sizeof(command), "/usr/sbin/reboot");
           }
           if (system_wrapper(command) != 0) {
-              dsme_log(LOG_ERR, "%s failed, trying again in 3s", command);
+              dsme_log(LOG_ERR, PFIX "%s failed, trying again in 3s", command);
               sleep(3);
               if (system_wrapper(command) != 0) {
-                  dsme_log(LOG_ERR, "%s failed again", command);
+                  dsme_log(LOG_ERR, PFIX "%s failed again", command);
                   goto fail_and_exit;
               }
           }
@@ -229,7 +231,7 @@ static void shutdown(dsme_runlevel_t runlevel)
   return;
 
 fail_and_exit:
-  dsme_log(LOG_CRIT, "Closing to clean-up!");
+  dsme_log(LOG_CRIT, PFIX "Closing to clean-up!");
   dsme_main_loop_quit(EXIT_FAILURE);
 }
 
@@ -251,7 +253,7 @@ static bool remount_mmc_readonly(void)
   /* Let's try to find the MMC in /proc/mounts */
   mounts_file = fopen("/proc/mounts", "r");
   if (!mounts_file) {
-      dsme_log(LOG_WARNING, "Can't open /proc/mounts. Leaving MMC as is");
+      dsme_log(LOG_WARNING, PFIX "Can't open /proc/mounts. Leaving MMC as is");
       return false;
   }
 
@@ -274,33 +276,33 @@ static bool remount_mmc_readonly(void)
       pid_t pid;
       pid_t rc;
 
-      dsme_log(LOG_WARNING, "MMC seems to be mounted, trying to mount read-only (%s %s).", device, mntpoint);
+      dsme_log(LOG_WARNING, PFIX "MMC seems to be mounted, trying to mount read-only (%s %s).", device, mntpoint);
 
       args[1] = (char*)&device;
       args[2] = (char*)&mntpoint;
       /* try to remount read-only */
       if ((pid = fork()) < 0) {
-          dsme_log(LOG_CRIT, "fork failed, exiting");
+          dsme_log(LOG_CRIT, PFIX "fork failed, exiting");
           return false;
       } else if (pid == 0) {
           execv("/bin/mount", args);
           execv("/sbin/mount", args);
 
-          dsme_log(LOG_ERR, "remount failed, no mount cmd found");
+          dsme_log(LOG_ERR, PFIX "remount failed, no mount cmd found");
           return false;
       }
       while ((rc = wait(&status)) != pid)
           if (rc < 0 && errno == ECHILD)
               break;
       if (rc != pid || WEXITSTATUS(status) != 0) {
-          dsme_log(LOG_ERR, "mount return value != 0, no can do.");
+          dsme_log(LOG_ERR, PFIX "mount return value != 0, no can do.");
           return false;
       }
 
-      dsme_log(LOG_NOTICE, "MMC remounted read-only");
+      dsme_log(LOG_NOTICE, PFIX "MMC remounted read-only");
       return true;
   } else {
-      dsme_log(LOG_NOTICE, "MMC not mounted");
+      dsme_log(LOG_NOTICE, PFIX "MMC not mounted");
       return true;
   }
 }
@@ -323,10 +325,10 @@ module_fn_info_t message_handlers[] = {
 
 void module_init(module_t* module)
 {
-  dsme_log(LOG_DEBUG, "runlevel.so loaded");
+  dsme_log(LOG_DEBUG, PFIX "runlevel.so loaded");
 }
 
 void module_fini(void)
 {
-  dsme_log(LOG_DEBUG, "runlevel.so unloaded");
+  dsme_log(LOG_DEBUG, PFIX "runlevel.so unloaded");
 }

--- a/modules/shutdownfeedback.c
+++ b/modules/shutdownfeedback.c
@@ -42,30 +42,30 @@ DSME_HANDLER(DSM_MSGTYPE_STATE_CHANGE_IND, conn, msg)
 {
     if ((msg->state == DSME_STATE_SHUTDOWN) ||
         (msg->state == DSME_STATE_REBOOT)) {
-        //dsme_log(LOG_DEBUG, PFIX"shutdown/reboot state received");
+        //dsme_log(LOG_DEBUG, PFIX "shutdown/reboot state received");
         dsme_play_vibra(pwroff_event_name);
     }
 }
 
 DSME_HANDLER(DSM_MSGTYPE_REBOOT_REQ, conn, msg)
 {
-    // dsme_log(LOG_DEBUG, PFIX"reboot reques received");
+    // dsme_log(LOG_DEBUG, PFIX "reboot reques received");
 }
 
 DSME_HANDLER(DSM_MSGTYPE_SHUTDOWN_REQ, conn, msg)
 {
-    //dsme_log(LOG_DEBUG, PFIX"shutdown reques received");
+    //dsme_log(LOG_DEBUG, PFIX "shutdown reques received");
 }
 
 DSME_HANDLER(DSM_MSGTYPE_DBUS_CONNECTED, conn, msg)
 {
-    dsme_log(LOG_INFO, PFIX"DBUS_CONNECTED");
+    dsme_log(LOG_INFO, PFIX "DBUS_CONNECTED");
     dsme_ini_vibrafeedback();
 }
 
 DSME_HANDLER(DSM_MSGTYPE_DBUS_DISCONNECT, conn, msg)
 {
-    dsme_log(LOG_INFO, PFIX"DBUS_DISCONNECT");
+    dsme_log(LOG_INFO, PFIX "DBUS_DISCONNECT");
 }
 
 module_fn_info_t message_handlers[] = {
@@ -79,11 +79,11 @@ module_fn_info_t message_handlers[] = {
 
 void module_init(module_t* handle)
 {
-    dsme_log(LOG_DEBUG, "shutdownfeedback.so loaded");
+    dsme_log(LOG_DEBUG, PFIX "shutdownfeedback.so loaded");
 }
 
 void module_fini(void)
 {
     dsme_fini_vibrafeedback();
-    dsme_log(LOG_DEBUG, "shutdownfeedback.so unloaded");
+    dsme_log(LOG_DEBUG, PFIX "shutdownfeedback.so unloaded");
 }

--- a/modules/shutdownfeedback.c
+++ b/modules/shutdownfeedback.c
@@ -77,7 +77,6 @@ module_fn_info_t message_handlers[] = {
     {0}
 };
 
-
 void module_init(module_t* handle)
 {
     dsme_log(LOG_DEBUG, "shutdownfeedback.so loaded");

--- a/modules/startup.c
+++ b/modules/startup.c
@@ -54,6 +54,8 @@
 #include <libgen.h>
 #include <limits.h>
 
+#define PFIX "startup: "
+
 #define STRINGIFY(x)  STRINGIFY2(x)
 #define STRINGIFY2(x) #x
 
@@ -128,7 +130,7 @@ DSME_HANDLER(DSM_MSGTYPE_GET_VERSION, client, ind)
 	DSM_MSGTYPE_DSME_VERSION msg     =
           DSME_MSG_INIT(DSM_MSGTYPE_DSME_VERSION);
 
-        dsme_log(LOG_DEBUG, "version requested, sending '%s'", version);
+        dsme_log(LOG_DEBUG, PFIX "version requested, sending '%s'", version);
 	endpoint_send_with_extra(client, &msg, strlen(version) + 1, version);
 }
 
@@ -139,7 +141,7 @@ module_fn_info_t message_handlers[] = {
 
 void module_init(module_t *handle)
 {
-	dsme_log(LOG_DEBUG, "DSME %s starting up", STRINGIFY(PRG_VERSION));
+	dsme_log(LOG_DEBUG, PFIX "DSME %s starting up", STRINGIFY(PRG_VERSION));
 
 	FILE       *conffile   = 0;
 	char       *modulename = 0;
@@ -147,13 +149,13 @@ void module_init(module_t *handle)
 	char        modulepath[PATH_MAX];
 
 	if( !(modulename = strdup(module_name(handle))) ) {
-		dsme_log(LOG_CRIT, "strdup failed");
+		dsme_log(LOG_CRIT, PFIX "strdup failed");
 		exit(EXIT_FAILURE);
 	}
 	moduledir = dirname(modulename);
 
 	if( !(conffile = fopen(MODULES_CONF, "r")) ) {
-		dsme_log(LOG_DEBUG, "Unable to read conffile (%s), using compiled-in startup list", MODULES_CONF);
+		dsme_log(LOG_DEBUG, PFIX "Unable to read conffile (%s), using compiled-in startup list", MODULES_CONF);
 
 		for( size_t i = 0; modules[i]; ++i ) {
 			int rc = snprintf(modulepath, sizeof modulepath, "%s/%s", moduledir, modules[i]);
@@ -162,12 +164,12 @@ void module_init(module_t *handle)
 				continue;
 			}
 			if( !modulebase_load_module(modulepath, 0) ) {
-				dsme_log(LOG_ERR, "error loading module %s", modulepath);
+				dsme_log(LOG_ERR, PFIX "error loading module %s", modulepath);
 			}
 		}
 	}
 	else {
-		dsme_log(LOG_DEBUG, "Conf file exists, reading modulenames from %s", MODULES_CONF);
+		dsme_log(LOG_DEBUG, PFIX "Conf file exists, reading modulenames from %s", MODULES_CONF);
 		size_t size = 0;
 		char  *line = NULL;
 		while( getline(&line, &size, conffile) > 0 ) {
@@ -178,7 +180,7 @@ void module_init(module_t *handle)
 				continue;
 			}
 			if (!modulebase_load_module(modulepath, 0) ) {
-				dsme_log(LOG_ERR, "error loading module %s", modulepath);
+				dsme_log(LOG_ERR, PFIX "error loading module %s", modulepath);
 			}
 		}
 		free(line);
@@ -186,5 +188,5 @@ void module_init(module_t *handle)
 	}
 
 	free(modulename);
-	dsme_log(LOG_DEBUG, "Module loading finished.");
+	dsme_log(LOG_DEBUG, PFIX "Module loading finished.");
 }

--- a/modules/state-internal.h
+++ b/modules/state-internal.h
@@ -34,6 +34,8 @@ typedef struct {
 } DSM_MSGTYPE_SET_USB_STATE;
 
 typedef dsmemsg_generic_t DSM_MSGTYPE_TELINIT;
+typedef dsmemsg_generic_t DSM_MSGTYPE_BLOCK_SHUTDOWN;
+typedef dsmemsg_generic_t DSM_MSGTYPE_ALLOW_SHUTDOWN;
 
 enum {
     /* NOTE: dsme message types are defined in:
@@ -48,8 +50,10 @@ enum {
      *    must be made aware of the new message type
      */
 
-    DSME_MSG_ENUM(DSM_MSGTYPE_SET_USB_STATE, 0x00000317),
-    DSME_MSG_ENUM(DSM_MSGTYPE_TELINIT,       0x00000318),
+    DSME_MSG_ENUM(DSM_MSGTYPE_SET_USB_STATE,  0x00000317),
+    DSME_MSG_ENUM(DSM_MSGTYPE_TELINIT,        0x00000318),
+    DSME_MSG_ENUM(DSM_MSGTYPE_BLOCK_SHUTDOWN, 0x0000031b),
+    DSME_MSG_ENUM(DSM_MSGTYPE_ALLOW_SHUTDOWN, 0x0000031c),
 };
 
 #endif

--- a/modules/state-internal.h
+++ b/modules/state-internal.h
@@ -28,14 +28,12 @@
 #include <dsme/messages.h>
 #include <stdbool.h>
 
-
 typedef struct {
     DSMEMSG_PRIVATE_FIELDS
     bool mounted_to_pc;
 } DSM_MSGTYPE_SET_USB_STATE;
 
 typedef dsmemsg_generic_t DSM_MSGTYPE_TELINIT;
-
 
 enum {
     /* NOTE: dsme message types are defined in:

--- a/modules/state.c
+++ b/modules/state.c
@@ -451,14 +451,14 @@ static bool need_to_use_reboot(dsme_state_t target_state)
 
     if( (input_fd = open(input_path, O_RDONLY)) == -1 ) {
         if( errno != ENOENT )
-            dsme_log(LOG_ERR, PFIX"%s: can't read reboot param: %m",
+            dsme_log(LOG_ERR, PFIX "%s: can't read reboot param: %m",
                      input_path);
         goto EXIT;
     }
 
     int todo = read(input_fd, param, sizeof param - 1);
     if( todo == -1 ) {
-        dsme_log(LOG_ERR, PFIX"%s: can't read reboot param: %m",
+        dsme_log(LOG_ERR, PFIX "%s: can't read reboot param: %m",
                  input_path);
         goto EXIT;
     }
@@ -471,7 +471,7 @@ static bool need_to_use_reboot(dsme_state_t target_state)
 
     output_fd = open(output_path, O_WRONLY|O_CREAT|O_TRUNC, 0644);
     if( output_fd == -1 ) {
-        dsme_log(LOG_ERR, PFIX"%s: can't write reboot param: %m",
+        dsme_log(LOG_ERR, PFIX "%s: can't write reboot param: %m",
                  output_path);
         goto EXIT;
     }
@@ -479,12 +479,12 @@ static bool need_to_use_reboot(dsme_state_t target_state)
     int done = write(output_fd, param, todo);
 
     if( done == -1 ) {
-        dsme_log(LOG_ERR, PFIX"%s: can't write reboot param: %m",
+        dsme_log(LOG_ERR, PFIX "%s: can't write reboot param: %m",
                  output_path);
         goto EXIT;
     }
     if( done != todo ) {
-        dsme_log(LOG_ERR, PFIX"%s: can't write reboot param: %s",
+        dsme_log(LOG_ERR, PFIX "%s: can't write reboot param: %s",
                  output_path, "partial write");;
         goto EXIT;
     }
@@ -492,7 +492,7 @@ static bool need_to_use_reboot(dsme_state_t target_state)
     /* Success - should use reboot instead of shutdown */
 
     use_reboot = true;
-    dsme_log(LOG_DEBUG, PFIX"%s: using '%s'", output_path, param);
+    dsme_log(LOG_DEBUG, PFIX "%s: using '%s'", output_path, param);
 
 EXIT:
     if( input_fd != -1 )
@@ -502,7 +502,7 @@ EXIT:
         close(output_fd);
 
     if( !use_reboot && unlink(output_path) == -1 && errno != ENOENT ) {
-        dsme_log(LOG_WARNING, PFIX"%s: can't remove reboot param: %m",
+        dsme_log(LOG_WARNING, PFIX "%s: can't remove reboot param: %m",
                  output_path);
     }
 
@@ -577,8 +577,7 @@ static void change_state_if_necessary(void)
 
 static void try_to_change_state(dsme_state_t new_state)
 {
-  dsme_log(LOG_INFO,
-           PFIX"state change request: %s -> %s",
+  dsme_log(LOG_INFO, PFIX "state change request: %s -> %s",
            state_name(current_state),
            state_name(new_state));
 
@@ -599,10 +598,9 @@ static void try_to_change_state(dsme_state_t new_state)
            * We don't allow that to happen if battery level is too low
            */
           if (dsme_battery_level < DSME_MINIMUM_BATTERY_TO_USER ) {
-              dsme_log(LOG_WARNING,
-                 PFIX"Battery level %d%% too low for %s state",
-                 dsme_battery_level,
-                 state_name(new_state));
+              dsme_log(LOG_WARNING, PFIX "Battery level %d%% too low for %s state",
+                       dsme_battery_level,
+                       state_name(new_state));
 #ifdef DSME_VIBRA_FEEDBACK
               /* Indicate by vibra that boot is not possible */
               dsme_play_vibra(low_battery_event_name);
@@ -619,7 +617,7 @@ static void try_to_change_state(dsme_state_t new_state)
           /* We don't support direct transfer from ACTDEAD to USER
            * but do it via reboot.
            */
-          dsme_log(LOG_DEBUG, PFIX"USER state requested, we do it via REBOOT");
+          dsme_log(LOG_DEBUG, PFIX "USER state requested, we do it via REBOOT");
           change_state(DSME_STATE_REBOOT);
           start_delayed_shutdown_timer(SHUTDOWN_TIMER_TIMEOUT);
 #else
@@ -644,12 +642,12 @@ static void try_to_change_state(dsme_state_t new_state)
            * Force SHUTDOWN
            */
           if( need_to_use_reboot(new_state) ) {
-              dsme_log(LOG_DEBUG, PFIX"ACTDEAD state requested, "
+              dsme_log(LOG_DEBUG, PFIX "ACTDEAD state requested, "
                        "we do it via REBOOT");
               change_state(DSME_STATE_REBOOT);
           }
           else {
-              dsme_log(LOG_DEBUG, PFIX"ACTDEAD state requested, "
+              dsme_log(LOG_DEBUG, PFIX "ACTDEAD state requested, "
                        "we do it via SHUTDOWN");
               change_state(DSME_STATE_SHUTDOWN);
           }
@@ -678,8 +676,7 @@ static void try_to_change_state(dsme_state_t new_state)
       break;
 
     default:
-      dsme_log(LOG_WARNING,
-               PFIX"not possible to change to state %s (%d)",
+      dsme_log(LOG_WARNING, PFIX "not possible to change to state %s (%d)",
                state_name(new_state),
                new_state);
       break;
@@ -699,7 +696,7 @@ static void change_state(dsme_state_t new_state)
       DSM_MSGTYPE_SAVE_DATA_IND save_msg =
         DSME_MSG_INIT(DSM_MSGTYPE_SAVE_DATA_IND);
 
-      dsme_log(LOG_DEBUG, PFIX"sending SAVE_DATA");
+      dsme_log(LOG_DEBUG, PFIX "sending SAVE_DATA");
       modules_broadcast(&save_msg);
   }
 
@@ -707,10 +704,10 @@ static void change_state(dsme_state_t new_state)
     DSME_MSG_INIT(DSM_MSGTYPE_STATE_CHANGE_IND);
 
   ind_msg.state = new_state;
-  dsme_log(LOG_DEBUG, PFIX"STATE_CHANGE_IND sent (%s)", state_name(new_state));
+  dsme_log(LOG_DEBUG, PFIX "STATE_CHANGE_IND sent (%s)", state_name(new_state));
   modules_broadcast(&ind_msg);
 
-  dsme_log(LOG_NOTICE, PFIX"new state: %s", state_name(new_state));
+  dsme_log(LOG_NOTICE, PFIX "new state: %s", state_name(new_state));
   current_state = new_state;
 }
 
@@ -738,8 +735,7 @@ static void deny_state_change_request(dsme_state_t denied_state,
 
   ind.state = denied_state;
   modules_broadcast_with_extra(&ind, strlen(reason) + 1, reason);
-  dsme_log(LOG_CRIT,
-           PFIX"%s denied due to: %s",
+  dsme_log(LOG_CRIT, PFIX "%s denied due to: %s",
            (denied_state == DSME_STATE_SHUTDOWN ? "shutdown" : "reboot"),
            reason);
 }
@@ -752,11 +748,11 @@ static void start_delayed_shutdown_timer(unsigned seconds)
                                                                delayed_shutdown_fn,
                                                                NULL)))
       {
-          dsme_log(LOG_CRIT, PFIX"Could not create a shutdown timer; exit!");
+          dsme_log(LOG_CRIT, PFIX "Could not create a shutdown timer; exit!");
           dsme_main_loop_quit(EXIT_FAILURE);
           return;
       }
-      dsme_log(LOG_NOTICE, PFIX"Shutdown or reboot in %i seconds", seconds);
+      dsme_log(LOG_NOTICE, PFIX "Shutdown or reboot in %i seconds", seconds);
   }
 }
 
@@ -779,12 +775,12 @@ static bool start_delayed_actdead_timer(unsigned seconds)
                                                               delayed_actdead_fn,
                                                               NULL)))
       {
-          dsme_log(LOG_CRIT, PFIX"Could not create an actdead timer; exit!");
+          dsme_log(LOG_CRIT, PFIX "Could not create an actdead timer; exit!");
           dsme_main_loop_quit(EXIT_FAILURE);
           return false;
       }
       success = true;
-      dsme_log(LOG_NOTICE, PFIX"Actdead in %i seconds", seconds);
+      dsme_log(LOG_NOTICE, PFIX "Actdead in %i seconds", seconds);
   }
   return success;
 }
@@ -808,12 +804,12 @@ static bool start_delayed_user_timer(unsigned seconds)
                                                            delayed_user_fn,
                                                            NULL)))
       {
-          dsme_log(LOG_CRIT, PFIX"Could not create a user timer; exit!");
+          dsme_log(LOG_CRIT, PFIX "Could not create a user timer; exit!");
           dsme_main_loop_quit(EXIT_FAILURE);
           return false;
       }
       success = true;
-      dsme_log(LOG_NOTICE, PFIX"User in %i seconds", seconds);
+      dsme_log(LOG_NOTICE, PFIX "User in %i seconds", seconds);
   }
   return success;
 }
@@ -840,17 +836,17 @@ static void stop_delayed_runlevel_timers(void)
     if (delayed_shutdown_timer) {
         dsme_destroy_timer(delayed_shutdown_timer);
         delayed_shutdown_timer = 0;
-        dsme_log(LOG_NOTICE, PFIX"Delayed shutdown timer stopped");
+        dsme_log(LOG_NOTICE, PFIX "Delayed shutdown timer stopped");
     }
     if (delayed_actdead_timer) {
         dsme_destroy_timer(delayed_actdead_timer);
         delayed_actdead_timer = 0;
-        dsme_log(LOG_NOTICE, PFIX"Delayed actdead timer stopped");
+        dsme_log(LOG_NOTICE, PFIX "Delayed actdead timer stopped");
     }
     if (delayed_user_timer) {
         dsme_destroy_timer(delayed_user_timer);
         delayed_user_timer = 0;
-        dsme_log(LOG_NOTICE, PFIX"Delayed user timer stopped");
+        dsme_log(LOG_NOTICE, PFIX "Delayed user timer stopped");
     }
 }
 
@@ -869,11 +865,10 @@ static void start_overheat_timer(void)
                                                        delayed_overheat_fn,
                                                        NULL)))
       {
-          dsme_log(LOG_CRIT, PFIX"Could not create a timer; overheat immediately!");
+          dsme_log(LOG_CRIT, PFIX "Could not create a timer; overheat immediately!");
           delayed_overheat_fn(0);
       } else {
-          dsme_log(LOG_CRIT,
-                   PFIX"Thermal shutdown in %d seconds",
+          dsme_log(LOG_CRIT, PFIX "Thermal shutdown in %d seconds",
                    DSME_THERMAL_SHUTDOWN_TIMER);
       }
   }
@@ -895,12 +890,10 @@ static void start_charger_disconnect_timer(int delay_s)
                                                                  delayed_charger_disconnect_fn,
                                                                  NULL)))
       {
-          dsme_log(LOG_ERR,
-                   PFIX"Could not create a timer; disconnect immediately!");
+          dsme_log(LOG_ERR, PFIX "Could not create a timer; disconnect immediately!");
           delayed_charger_disconnect_fn(0);
       } else {
-          dsme_log(LOG_DEBUG,
-                   PFIX"Handle charger disconnect in %d seconds",
+          dsme_log(LOG_DEBUG, PFIX "Handle charger disconnect in %d seconds",
                    delay_s);
       }
   }
@@ -920,7 +913,7 @@ static void stop_charger_disconnect_timer(void)
   if (charger_disconnect_timer) {
       dsme_destroy_timer(charger_disconnect_timer);
       charger_disconnect_timer = 0;
-      dsme_log(LOG_DEBUG, PFIX"Charger disconnect timer stopped");
+      dsme_log(LOG_DEBUG, PFIX "Charger disconnect timer stopped");
 
       /* the last we heard, the charger had just been disconnected */
       set_charger_state(CHARGER_DISCONNECTED);
@@ -931,8 +924,7 @@ DSME_HANDLER(DSM_MSGTYPE_SET_CHARGER_STATE, conn, msg)
 {
   charger_state_t new_charger_state;
 
-  dsme_log(LOG_DEBUG,
-           PFIX"charger %s state received",
+  dsme_log(LOG_DEBUG, PFIX "charger %s state received",
            msg->connected ? "connected" : "disconnected");
 
   new_charger_state = msg->connected ? CHARGER_CONNECTED : CHARGER_DISCONNECTED;
@@ -969,13 +961,13 @@ DSME_HANDLER(DSM_MSGTYPE_SET_USB_STATE, conn, msg)
 // handlers for telinit requests
 static void handle_telinit_NOT_SET(endpoint_t* conn)
 {
-    dsme_log(LOG_WARNING, PFIX"ignoring unknown telinit runlevel request");
+    dsme_log(LOG_WARNING, PFIX "ignoring unknown telinit runlevel request");
 }
 
 static void handle_telinit_SHUTDOWN(endpoint_t* conn)
 {
     if( !endpoint_is_privileged(conn) ) {
-        dsme_log(LOG_WARNING, PFIX"shutdown request from unprivileged client");
+        dsme_log(LOG_WARNING, PFIX "shutdown request from unprivileged client");
     }
     else if (is_state_change_request_acceptable(DSME_STATE_SHUTDOWN)) {
         set_shutdown_requested(true);
@@ -987,7 +979,7 @@ static void handle_telinit_SHUTDOWN(endpoint_t* conn)
 static void handle_telinit_USER(endpoint_t* conn)
 {
     if( !endpoint_is_privileged(conn) ) {
-        dsme_log(LOG_WARNING, PFIX"powerup request from unprivileged client");
+        dsme_log(LOG_WARNING, PFIX "powerup request from unprivileged client");
     }
     else {
         set_shutdown_requested(false);
@@ -999,7 +991,7 @@ static void handle_telinit_USER(endpoint_t* conn)
 static void handle_telinit_ACTDEAD(endpoint_t* conn)
 {
     if( !endpoint_is_privileged(conn) ) {
-        dsme_log(LOG_WARNING, PFIX"actdead request from unprivileged client");
+        dsme_log(LOG_WARNING, PFIX "actdead request from unprivileged client");
     }
     else if (is_state_change_request_acceptable(DSME_STATE_ACTDEAD)) {
         set_actdead_requested(true);
@@ -1010,7 +1002,7 @@ static void handle_telinit_ACTDEAD(endpoint_t* conn)
 static void handle_telinit_REBOOT(endpoint_t* conn)
 {
     if( !endpoint_is_privileged(conn) ) {
-        dsme_log(LOG_WARNING, PFIX"reboot request from unprivileged client");
+        dsme_log(LOG_WARNING, PFIX "reboot request from unprivileged client");
     }
     else if (is_state_change_request_acceptable(DSME_STATE_REBOOT)) {
         set_reboot_requested(true);
@@ -1021,22 +1013,22 @@ static void handle_telinit_REBOOT(endpoint_t* conn)
 
 static void handle_telinit_TEST(endpoint_t* conn)
 {
-    dsme_log(LOG_WARNING, PFIX"telinit TEST unimplemented");
+    dsme_log(LOG_WARNING, PFIX "telinit TEST unimplemented");
 }
 
 static void handle_telinit_MALF(endpoint_t* conn)
 {
-    dsme_log(LOG_WARNING, PFIX"telinit MALF unimplemented");
+    dsme_log(LOG_WARNING, PFIX "telinit MALF unimplemented");
 }
 
 static void handle_telinit_BOOT(endpoint_t* conn)
 {
-    dsme_log(LOG_WARNING, PFIX"telinit BOOT unimplemented");
+    dsme_log(LOG_WARNING, PFIX "telinit BOOT unimplemented");
 }
 
 static void handle_telinit_LOCAL(endpoint_t* conn)
 {
-    dsme_log(LOG_WARNING, PFIX"telinit LOCAL unimplemented");
+    dsme_log(LOG_WARNING, PFIX "telinit LOCAL unimplemented");
 }
 
 typedef void (telinit_handler_fn_t)(endpoint_t* conn);
@@ -1071,8 +1063,7 @@ DSME_HANDLER(DSM_MSGTYPE_TELINIT, conn, msg)
     const char* runlevel = DSMEMSG_EXTRA(msg);
     char*       sender   = endpoint_name(conn);
 
-    dsme_log(LOG_NOTICE,
-             PFIX"got telinit '%s' from %s",
+    dsme_log(LOG_NOTICE, PFIX "got telinit '%s' from %s",
              runlevel ? runlevel : "(null)",
              sender   ? sender   : "(unknown)");
     free(sender);
@@ -1089,8 +1080,7 @@ DSME_HANDLER(DSM_MSGTYPE_TELINIT, conn, msg)
 DSME_HANDLER(DSM_MSGTYPE_SHUTDOWN_REQ, conn, msg)
 {
   char* sender = endpoint_name(conn);
-  dsme_log(LOG_NOTICE,
-           PFIX"shutdown request received from %s",
+  dsme_log(LOG_NOTICE, PFIX "shutdown request received from %s",
            (sender ? sender : "(unknown)"));
   free(sender);
 
@@ -1100,8 +1090,7 @@ DSME_HANDLER(DSM_MSGTYPE_SHUTDOWN_REQ, conn, msg)
 DSME_HANDLER(DSM_MSGTYPE_REBOOT_REQ, conn, msg)
 {
   char* sender = endpoint_name(conn);
-  dsme_log(LOG_NOTICE,
-           PFIX"reboot request received from %s",
+  dsme_log(LOG_NOTICE, PFIX "reboot request received from %s",
            (sender ? sender : "(unknown)"));
   free(sender);
 
@@ -1115,8 +1104,7 @@ DSME_HANDLER(DSM_MSGTYPE_REBOOT_REQ, conn, msg)
 DSME_HANDLER(DSM_MSGTYPE_POWERUP_REQ, conn, msg)
 {
   char* sender = endpoint_name(conn);
-  dsme_log(LOG_NOTICE,
-           PFIX"powerup request received from %s",
+  dsme_log(LOG_NOTICE, PFIX "powerup request received from %s",
            (sender ? sender : "(unknown)"));
   free(sender);
 
@@ -1125,8 +1113,7 @@ DSME_HANDLER(DSM_MSGTYPE_POWERUP_REQ, conn, msg)
 
 DSME_HANDLER(DSM_MSGTYPE_SET_ALARM_STATE, conn, msg)
 {
-  dsme_log(LOG_DEBUG,
-           PFIX"alarm %s state received",
+  dsme_log(LOG_DEBUG, PFIX "alarm %s state received",
            msg->alarm_set ? "set or snoozed" : "not set");
 
   set_alarm_pending(msg->alarm_set);
@@ -1136,8 +1123,7 @@ DSME_HANDLER(DSM_MSGTYPE_SET_ALARM_STATE, conn, msg)
 
 DSME_HANDLER(DSM_MSGTYPE_SET_THERMAL_STATUS, conn, msg)
 {
-  dsme_log(LOG_NOTICE,
-           PFIX"%s state received",
+  dsme_log(LOG_NOTICE, PFIX "%s state received",
            (msg->status == DSM_THERMAL_STATUS_OVERHEATED) ? "overheated" :
            (msg->status == DSM_THERMAL_STATUS_LOWTEMP) ? "low temp warning" :
            "normal temp");
@@ -1151,8 +1137,7 @@ DSME_HANDLER(DSM_MSGTYPE_SET_THERMAL_STATUS, conn, msg)
 
 DSME_HANDLER(DSM_MSGTYPE_SET_EMERGENCY_CALL_STATE, conn, msg)
 {
-  dsme_log(LOG_NOTICE,
-           PFIX"emergency call %s state received",
+  dsme_log(LOG_NOTICE, PFIX "emergency call %s state received",
            msg->ongoing ? "on" : "off");
 
   update_emergency_call_ongoing(msg->ongoing);
@@ -1185,14 +1170,12 @@ static void start_battery_empty_timer(void)
                                                     NULL);
     if (!battery_empty_timer)
     {
-      dsme_log(LOG_ERR,
-               PFIX"Cannot create timer; battery empty shutdown immediately!");
+      dsme_log(LOG_ERR, PFIX "Cannot create timer; battery empty shutdown immediately!");
       delayed_battery_empty_fn(0);
     }
     else
     {
-      dsme_log(LOG_CRIT,
-               PFIX"Battery empty shutdown in %d seconds",
+      dsme_log(LOG_CRIT, PFIX "Battery empty shutdown in %d seconds",
                DSME_BATTERY_EMPTY_SHUTDOWN_TIMER);
     }
   }
@@ -1200,7 +1183,7 @@ static void start_battery_empty_timer(void)
 
 DSME_HANDLER(DSM_MSGTYPE_SET_BATTERY_LEVEL, conn, battery)
 {
-    dsme_log(LOG_INFO, PFIX"battery level=%d received",
+    dsme_log(LOG_INFO, PFIX "battery level=%d received",
              battery->level);
 
     dsme_battery_level = battery->level;
@@ -1208,8 +1191,7 @@ DSME_HANDLER(DSM_MSGTYPE_SET_BATTERY_LEVEL, conn, battery)
 
 DSME_HANDLER(DSM_MSGTYPE_SET_BATTERY_STATE, conn, battery)
 {
-  dsme_log(LOG_NOTICE,
-           PFIX"battery %s state received",
+  dsme_log(LOG_NOTICE, PFIX "battery %s state received",
            battery->empty ? "empty" : "not empty");
 
   if (battery->empty) {
@@ -1233,7 +1215,7 @@ DSME_HANDLER(DSM_MSGTYPE_STATE_QUERY, client, msg)
   DSM_MSGTYPE_STATE_CHANGE_IND ind_msg =
     DSME_MSG_INIT(DSM_MSGTYPE_STATE_CHANGE_IND);
 
-  dsme_log(LOG_DEBUG, PFIX"state_query, state: %s", state_name(current_state));
+  dsme_log(LOG_DEBUG, PFIX "state_query, state: %s", state_name(current_state));
 
   ind_msg.state = current_state;
   endpoint_send(client, &ind_msg);
@@ -1247,11 +1229,11 @@ static bool rd_mode_enabled(void)
   bool          enabled;
 
   if (dsme_rd_mode_enabled()) {
-      dsme_log(LOG_NOTICE, PFIX"R&D mode enabled");
+      dsme_log(LOG_NOTICE, PFIX "R&D mode enabled");
       enabled = true;
   } else {
       enabled = false;
-      dsme_log(LOG_DEBUG, PFIX"R&D mode disabled");
+      dsme_log(LOG_DEBUG, PFIX "R&D mode disabled");
   }
 
   return enabled;
@@ -1270,7 +1252,7 @@ static void runlevel_switch_ind(const DsmeDbusMessage* ind)
         case DSME_RUNLEVEL_ACTDEAD: {
             /*  USER -> ACTDEAD runlevel change done */
             set_actdead_switch_done(true);
-            dsme_log(LOG_DEBUG, PFIX"USER -> ACTDEAD runlevel change done");
+            dsme_log(LOG_DEBUG, PFIX "USER -> ACTDEAD runlevel change done");
 
             /* Do we have a pending ACTDEAD -> USER timer? */
             if (delayed_user_timer) {
@@ -1283,7 +1265,7 @@ static void runlevel_switch_ind(const DsmeDbusMessage* ind)
         case DSME_RUNLEVEL_USER: {
             /* ACTDEAD -> USER runlevel change done */
             set_user_switch_done(true);
-            dsme_log(LOG_DEBUG, PFIX"ACTDEAD -> USER runlevel change done");
+            dsme_log(LOG_DEBUG, PFIX "ACTDEAD -> USER runlevel change done");
 
             /* Do we have a pending USER -> ACTDEAD timer? */
             if (delayed_actdead_timer) {
@@ -1297,7 +1279,7 @@ static void runlevel_switch_ind(const DsmeDbusMessage* ind)
             /*
              * Currently, we only get a runlevel switch signal for USER and ACTDEAD (NB#199301)
              */
-            dsme_log(LOG_NOTICE, PFIX"Unhandled runlevel switch indicator signal. runlevel: %i", runlevel_ind);
+            dsme_log(LOG_NOTICE, PFIX "Unhandled runlevel switch indicator signal. runlevel: %i", runlevel_ind);
             break;
         }
     }
@@ -1312,7 +1294,7 @@ static const dsme_dbus_signal_binding_t dbus_signals_array[] = {
 
 DSME_HANDLER(DSM_MSGTYPE_DBUS_CONNECTED, client, msg)
 {
-  dsme_log(LOG_DEBUG, PFIX"DBUS_CONNECTED");
+  dsme_log(LOG_DEBUG, PFIX "DBUS_CONNECTED");
   dsme_dbus_bind_signals(&dbus_signals_bound, dbus_signals_array);
 #ifdef DSME_VIBRA_FEEDBACK
   dsme_ini_vibrafeedback();
@@ -1321,7 +1303,7 @@ DSME_HANDLER(DSM_MSGTYPE_DBUS_CONNECTED, client, msg)
 
 DSME_HANDLER(DSM_MSGTYPE_DBUS_DISCONNECT, client, msg)
 {
-  dsme_log(LOG_DEBUG, PFIX"DBUS_DISCONNECT");
+  dsme_log(LOG_DEBUG, PFIX "DBUS_DISCONNECT");
 }
 
 DSME_HANDLER(DSM_MSGTYPE_BLOCK_SHUTDOWN, client, msg)
@@ -1483,7 +1465,7 @@ static void set_initial_state_bits(const char* bootstate)
           enter_malf(reason, component, details);
           free(malf_info);
       } else {
-          dsme_log(LOG_NOTICE, PFIX"R&D mode enabled, not entering MALF '%s'", p);
+          dsme_log(LOG_NOTICE, PFIX "R&D mode enabled, not entering MALF '%s'", p);
       }
   }
 }
@@ -1494,22 +1476,21 @@ void module_init(module_t* handle)
    * Instead, wait for DSM_MSGTYPE_DBUS_CONNECTED.
    */
 
-  dsme_log(LOG_DEBUG, "state.so started");
+  dsme_log(LOG_DEBUG, PFIX "state.so started");
 
   const char* bootstate = getenv("BOOTSTATE");
   if (!bootstate) {
       bootstate = "USER";
-      dsme_log(LOG_NOTICE,
-               PFIX"BOOTSTATE: No such environment variable, using '%s'",
+      dsme_log(LOG_NOTICE, PFIX "BOOTSTATE: No such environment variable, using '%s'",
                bootstate);
   } else {
-      dsme_log(LOG_INFO, PFIX"BOOTSTATE: '%s'", bootstate);
+      dsme_log(LOG_INFO, PFIX "BOOTSTATE: '%s'", bootstate);
   }
 
   set_initial_state_bits(bootstate);
   change_state_if_necessary();
 
-  dsme_log(LOG_DEBUG, PFIX"Startup state: %s", state_name(current_state));
+  dsme_log(LOG_DEBUG, PFIX "Startup state: %s", state_name(current_state));
 }
 
 void module_fini(void)
@@ -1522,5 +1503,5 @@ void module_fini(void)
   stop_charger_disconnect_timer();
   stop_overheat_timer();
   stop_battery_empty_timer();
-  dsme_log(LOG_DEBUG, "state.so unloaded");
+  dsme_log(LOG_DEBUG, PFIX "state.so unloaded");
 }

--- a/modules/state.c
+++ b/modules/state.c
@@ -104,7 +104,7 @@
 #define DSME_THERMAL_SHUTDOWN_TIMER       8
 #define DSME_BATTERY_EMPTY_SHUTDOWN_TIMER 8
 
-/** 
+/**
  * Minimum battery level % that is needed before we allow
  * switch from ACTDEAD to USER
  * TODO: don't hard code this but support config value
@@ -116,7 +116,6 @@ typedef enum {
     CHARGER_CONNECTED,
     CHARGER_DISCONNECTED,
 } charger_state_t;
-
 
 /* these are the state bits on which dsme bases its state selection */
 charger_state_t charger_state          = CHARGER_STATE_UNKNOWN;
@@ -326,7 +325,6 @@ static bool need_to_use_reboot(dsme_state_t target_state)
     dsme_log(LOG_DEBUG, PFIX"%s: using '%s'", output_path, param);
 
 EXIT:
-
     if( input_fd != -1 )
         close(input_fd);
 
@@ -347,12 +345,9 @@ static dsme_state_t select_state(void)
   dsme_state_t state;
 
   if (emergency_call_ongoing) {
-
       /* don't touch anything if we have an emergency call going on */
       state = current_state;
-
   } else {
-
       if (test) {
           state = DSME_STATE_TEST;
       } else if (battery_empty) {
@@ -389,7 +384,6 @@ static dsme_state_t select_state(void)
       } else {
           state = DSME_STATE_USER;
       }
-
   }
   return state;
 }
@@ -411,7 +405,6 @@ static void try_to_change_state(dsme_state_t new_state)
            state_name(new_state));
 
   switch (new_state) {
-
     case DSME_STATE_SHUTDOWN: /* Runlevel 0 */ /* FALL THROUGH */
     case DSME_STATE_REBOOT:   /* Runlevel 6 */
       change_state(new_state);
@@ -456,12 +449,12 @@ static void try_to_change_state(dsme_state_t new_state)
               /* actdead init done; runlevel change from actdead to user state */
               if (start_delayed_user_timer(USER_TIMER_MIN_TIMEOUT)) {
                   change_state(new_state);
-              } 
+              }
           } else {
               /* actdead init not done; wait longer to change from actdead to user state */
               if (start_delayed_user_timer(USER_TIMER_MAX_TIMEOUT)) {
                   change_state(new_state);
-              } 
+              }
           }
 #endif /* DSME_SUPPORT_DIRECT_USER_ACTDEAD */
       } else if (current_state == DSME_STATE_USER) {
@@ -488,12 +481,12 @@ static void try_to_change_state(dsme_state_t new_state)
               /* user init done; runlevel change from user to actdead state */
               if (start_delayed_actdead_timer(ACTDEAD_TIMER_MIN_TIMEOUT)) {
                   change_state(new_state);
-              } 
+              }
           } else {
               /* user init not done; wait longer to change from user to actdead state */
               if (start_delayed_actdead_timer(ACTDEAD_TIMER_MAX_TIMEOUT)) {
                   change_state(new_state);
-              } 
+              }
           }
 #endif /* DSME_SUPPORT_DIRECT_USER_ACTDEAD */
       }
@@ -513,7 +506,6 @@ static void try_to_change_state(dsme_state_t new_state)
                new_state);
       break;
   }
-
 }
 
 /**
@@ -544,7 +536,6 @@ static void change_state(dsme_state_t new_state)
   current_state = new_state;
 }
 
-
 static bool is_state_change_request_acceptable(dsme_state_t requested_state)
 {
     bool acceptable = true;
@@ -561,7 +552,6 @@ static bool is_state_change_request_acceptable(dsme_state_t requested_state)
     return acceptable;
 }
 
-
 static void deny_state_change_request(dsme_state_t denied_state,
                                       const char*  reason)
 {
@@ -575,7 +565,6 @@ static void deny_state_change_request(dsme_state_t denied_state,
            (denied_state == DSME_STATE_SHUTDOWN ? "shutdown" : "reboot"),
            reason);
 }
-
 
 static void start_delayed_shutdown_timer(unsigned seconds)
 {
@@ -625,7 +614,6 @@ static bool start_delayed_actdead_timer(unsigned seconds)
 
 static int delayed_actdead_fn(void* unused)
 {
-
   change_runlevel(DSME_STATE_ACTDEAD);
 
   delayed_actdead_timer = 0;
@@ -742,7 +730,6 @@ static void start_charger_disconnect_timer(int delay_s)
 
 static int delayed_charger_disconnect_fn(void* unused)
 {
-
   charger_state = CHARGER_DISCONNECTED;
   change_state_if_necessary();
 
@@ -761,7 +748,6 @@ static void stop_charger_disconnect_timer(void)
       charger_state = CHARGER_DISCONNECTED;
   }
 }
-
 
 DSME_HANDLER(DSM_MSGTYPE_SET_CHARGER_STATE, conn, msg)
 {
@@ -797,7 +783,6 @@ DSME_HANDLER(DSM_MSGTYPE_SET_CHARGER_STATE, conn, msg)
   }
 }
 
-
 DSME_HANDLER(DSM_MSGTYPE_SET_USB_STATE, conn, msg)
 {
     if (mounted_to_pc != msg->mounted_to_pc) {
@@ -806,7 +791,6 @@ DSME_HANDLER(DSM_MSGTYPE_SET_USB_STATE, conn, msg)
         dsme_log(LOG_INFO, PFIX"%smounted over USB", mounted_to_pc ? "" : "not ");
     }
 }
-
 
 // handlers for telinit requests
 static void handle_telinit_NOT_SET(endpoint_t* conn)
@@ -965,7 +949,6 @@ DSME_HANDLER(DSM_MSGTYPE_POWERUP_REQ, conn, msg)
   handle_telinit_USER(conn);
 }
 
-
 DSME_HANDLER(DSM_MSGTYPE_SET_ALARM_STATE, conn, msg)
 {
   dsme_log(LOG_DEBUG,
@@ -976,7 +959,6 @@ DSME_HANDLER(DSM_MSGTYPE_SET_ALARM_STATE, conn, msg)
 
   change_state_if_necessary();
 }
-
 
 DSME_HANDLER(DSM_MSGTYPE_SET_THERMAL_STATUS, conn, msg)
 {
@@ -992,7 +974,6 @@ DSME_HANDLER(DSM_MSGTYPE_SET_THERMAL_STATUS, conn, msg)
       /* there is no going back from being overheated */
   }
 }
-
 
 DSME_HANDLER(DSM_MSGTYPE_SET_EMERGENCY_CALL_STATE, conn, msg)
 {
@@ -1078,7 +1059,6 @@ DSME_HANDLER(DSM_MSGTYPE_SET_BATTERY_STATE, conn, battery)
   }
 }
 
-
 DSME_HANDLER(DSM_MSGTYPE_STATE_QUERY, client, msg)
 {
   DSM_MSGTYPE_STATE_CHANGE_IND ind_msg =
@@ -1089,7 +1069,6 @@ DSME_HANDLER(DSM_MSGTYPE_STATE_QUERY, client, msg)
   ind_msg.state = current_state;
   endpoint_send(client, &ind_msg);
 }
-
 
 /**
  * Reads the RD mode state and returns true if enabled
@@ -1194,7 +1173,6 @@ module_fn_info_t message_handlers[] = {
       {0}
 };
 
-
 static void parse_malf_info(char*  malf_info,
                             char** reason,
                             char** component,
@@ -1270,19 +1248,15 @@ static void set_initial_state_bits(const char* bootstate)
       // TODO: does getbootstate ever return "SHUTDOWN"?
       charger_state      = CHARGER_DISCONNECTED;
       shutdown_requested = true;
-
   } else if ((p = DSME_SKIP_PREFIX(bootstate, "USER"))) {
       // DSME_STATE_USER with possible malf information
-
   } else if ((p = DSME_SKIP_PREFIX(bootstate, "ACT_DEAD"))) {
       // DSME_STATE_ACTDEAD with possible malf information
       shutdown_requested = true;
-
   } else if (strcmp(bootstate, "BOOT") == 0) {
       // DSME_STATE_REBOOT
       // TODO: does getbootstate ever return "BOOT"?
       reboot_requested = true;
-
   } else if (strcmp(bootstate, "LOCAL") == 0 ||
              strcmp(bootstate, "TEST")  == 0 ||
              strcmp(bootstate, "FLASH") == 0)
@@ -1314,7 +1288,6 @@ static void set_initial_state_bits(const char* bootstate)
           parse_malf_info(malf_info, &reason, &component, &details);
           enter_malf(reason, component, details);
           free(malf_info);
-
       } else {
           dsme_log(LOG_NOTICE, PFIX"R&D mode enabled, not entering MALF '%s'", p);
       }

--- a/modules/thermalflagger.c
+++ b/modules/thermalflagger.c
@@ -36,9 +36,7 @@
 #include <unistd.h>
 #include <string.h>
 
-
 #define DSME_THERMAL_FLAG_FILE "/var/lib/dsme/force_shutdown"
-
 
 static void write_thermal_flag(void)
 {

--- a/modules/thermalflagger.c
+++ b/modules/thermalflagger.c
@@ -36,14 +36,15 @@
 #include <unistd.h>
 #include <string.h>
 
+#define PFIX "thermalflagger: "
+
 #define DSME_THERMAL_FLAG_FILE "/var/lib/dsme/force_shutdown"
 
 static void write_thermal_flag(void)
 {
     int i = open(DSME_THERMAL_FLAG_FILE, O_WRONLY | O_CREAT, 0644);
     if (i == -1 || fsync(i) == -1 || close(i) == -1) {
-        dsme_log(LOG_ERR,
-                 "Error creating %s: %s",
+        dsme_log(LOG_ERR, PFIX "Error creating %s: %s",
                  DSME_THERMAL_FLAG_FILE,
                  strerror(errno));
     }
@@ -52,8 +53,7 @@ static void write_thermal_flag(void)
 static void remove_thermal_flag(void)
 {
     if (unlink(DSME_THERMAL_FLAG_FILE) == -1 && errno != ENOENT) {
-        dsme_log(LOG_WARNING,
-                 "Error removing %s: %s",
+        dsme_log(LOG_WARNING, PFIX "Error removing %s: %s",
                  DSME_THERMAL_FLAG_FILE,
                  strerror(errno));
     }
@@ -75,12 +75,12 @@ module_fn_info_t message_handlers[] = {
 
 void module_init(module_t* handle)
 {
-  dsme_log(LOG_DEBUG, "thermalflagger.so loaded");
+  dsme_log(LOG_DEBUG, PFIX "thermalflagger.so loaded");
 
   remove_thermal_flag();
 }
 
 void module_fini(void)
 {
-  dsme_log(LOG_DEBUG, "thermalflagger.so unloaded");
+  dsme_log(LOG_DEBUG, PFIX "thermalflagger.so unloaded");
 }

--- a/modules/thermalmanager.c
+++ b/modules/thermalmanager.c
@@ -404,11 +404,11 @@ thermal_manager_schedule_object_poll(thermal_object_t *thermal_object)
     }
 
     if( mintime == maxtime ) {
-        dsme_log(LOG_DEBUG, PFIX"%s: check again in %d sec global slot",
+        dsme_log(LOG_DEBUG, PFIX "%s: check again in %d sec global slot",
                  thermal_object_get_name(thermal_object), mintime);
     }
     else {
-        dsme_log(LOG_DEBUG, PFIX"%s: check again in %d to %d seconds",
+        dsme_log(LOG_DEBUG, PFIX "%s: check again in %d to %d seconds",
                  thermal_object_get_name(thermal_object), mintime, maxtime);
     }
 
@@ -459,7 +459,7 @@ thermal_manager_register_object(thermal_object_t *thermal_object)
     if( thermal_manager_object_is_registered(thermal_object) )
         goto EXIT;
 
-    dsme_log(LOG_DEBUG, PFIX"%s: registered",
+    dsme_log(LOG_DEBUG, PFIX "%s: registered",
              thermal_object_get_name(thermal_object));
 
     // add the thermal object to the list of know thermal objects
@@ -503,7 +503,7 @@ thermal_manager_unregister_object(thermal_object_t *thermal_object)
     // remove the thermal object from the list of know thermal objects
     thermal_objects = g_slist_remove(thermal_objects, thermal_object);
 
-    dsme_log(LOG_DEBUG, PFIX"%s: unregistered",
+    dsme_log(LOG_DEBUG, PFIX "%s: unregistered",
              thermal_object_get_name(thermal_object));
 
 EXIT:
@@ -777,18 +777,18 @@ thermal_manager_broadcast_status_dsme(THERMAL_STATUS status,
     /* Log state change */
     switch( curr ) {
     case DSM_THERMAL_STATUS_LOWTEMP:
-        dsme_log(LOG_WARNING, PFIX"policy: low temperature (%s %dC)",
+        dsme_log(LOG_WARNING, PFIX "policy: low temperature (%s %dC)",
                  sensor_name, temperature);
         break;
 
     default:
     case DSM_THERMAL_STATUS_NORMAL:
-        dsme_log(LOG_NOTICE, PFIX"policy: acceptable temperature (%s %dC)",
+        dsme_log(LOG_NOTICE, PFIX "policy: acceptable temperature (%s %dC)",
                  sensor_name, temperature);
         break;
 
     case DSM_THERMAL_STATUS_OVERHEATED:
-        dsme_log(LOG_CRIT, PFIX"policy: overheated (%s %dC)", sensor_name,
+        dsme_log(LOG_CRIT, PFIX "policy: overheated (%s %dC)", sensor_name,
                  temperature);
         break;
     }
@@ -826,7 +826,7 @@ thermal_manager_broadcast_status_dbus(THERMAL_STATUS status)
 
     const char *arg = thermal_status_name(status);
 
-    dsme_log(LOG_NOTICE, PFIX"send dbus signal %s.%s(%s)",
+    dsme_log(LOG_NOTICE, PFIX "send dbus signal %s.%s(%s)",
              thermalmanager_interface,
              thermalmanager_state_change_ind, arg);
 
@@ -1128,7 +1128,7 @@ EXIT:
  */
 DSME_HANDLER(DSM_MSGTYPE_DBUS_CONNECTED, client, msg)
 {
-    dsme_log(LOG_DEBUG, PFIX"DBUS_CONNECTED");
+    dsme_log(LOG_DEBUG, PFIX "DBUS_CONNECTED");
 
     /* Add dbus method call handlers */
     dsme_dbus_bind_methods(&dbus_methods_bound,
@@ -1142,7 +1142,7 @@ DSME_HANDLER(DSM_MSGTYPE_DBUS_CONNECTED, client, msg)
  */
 DSME_HANDLER(DSM_MSGTYPE_DBUS_DISCONNECT, client, msg)
 {
-    dsme_log(LOG_DEBUG, PFIX"DBUS_DISCONNECT");
+    dsme_log(LOG_DEBUG, PFIX "DBUS_DISCONNECT");
 }
 
 /** Array of DSME event handlers implemented by this plugin */
@@ -1165,7 +1165,7 @@ module_fn_info_t message_handlers[] =
 void
 module_init(module_t *handle)
 {
-    dsme_log(LOG_DEBUG, PFIX"loaded");
+    dsme_log(LOG_DEBUG, PFIX "loaded");
 
     this_module = handle;
 }
@@ -1177,7 +1177,7 @@ module_fini(void)
 {
     /* Clear remaining thermal objects from the registered list */
     if( thermal_objects ) {
-        dsme_log(LOG_ERR, PFIX"registered thermal objects remain "
+        dsme_log(LOG_ERR, PFIX "registered thermal objects remain "
                  "at unload time");
 
         do
@@ -1192,5 +1192,5 @@ module_fini(void)
                              thermalmanager_interface,
                              dbus_methods_array);
 
-    dsme_log(LOG_DEBUG, PFIX"unloaded");
+    dsme_log(LOG_DEBUG, PFIX "unloaded");
 }

--- a/modules/thermalmanager.c
+++ b/modules/thermalmanager.c
@@ -623,7 +623,6 @@ thermal_manager_get_sensor_status(const char *sensor_name,
     ack = true;
 
 EXIT:
-
     --recursing;
 
     return ack;

--- a/modules/thermalmanager.h
+++ b/modules/thermalmanager.h
@@ -119,7 +119,6 @@ struct thermal_sensor_vtab_t
 
     /** Hook required by thermal_object_read_sensor() */
     bool        (*tsv_read_sensor_cb)(thermal_object_t *);
-
 };
 
 /* ------------------------------------------------------------------------- *

--- a/modules/thermalobject.c
+++ b/modules/thermalobject.c
@@ -513,7 +513,6 @@ thermal_object_request_update(thermal_object_t *self)
     }
 
 EXIT:
-
     /* If the lower level request failed, notify upper level
      * logic immediately */
 
@@ -653,7 +652,6 @@ thermal_object_handle_update(thermal_object_t *self)
 #endif
 
 EXIT:
-
     if( notify ) {
         /* Update the thermal object itself */
         thermal_manager_handle_object_update(self);

--- a/modules/thermalobject.c
+++ b/modules/thermalobject.c
@@ -169,7 +169,7 @@ thermal_object_create(const thermal_sensor_vtab_t *vtab, void *data)
     self->to_sensor_vtab = vtab;
     self->to_sensor_data = data;
 
-    dsme_log(LOG_DEBUG, PFIX"%s: created", thermal_object_get_name(self));
+    dsme_log(LOG_DEBUG, PFIX "%s: created", thermal_object_get_name(self));
 
     return self;
 }
@@ -186,7 +186,7 @@ thermal_object_delete(thermal_object_t *self)
 
     thermal_manager_unregister_object(self);
 
-    dsme_log(LOG_DEBUG, PFIX"%s: deleted", thermal_object_get_name(self));
+    dsme_log(LOG_DEBUG, PFIX "%s: deleted", thermal_object_get_name(self));
 
     if( thermal_object_has_valid_sensor_vtab(self) )
         self->to_sensor_vtab->tsv_delete_cb(self);
@@ -365,14 +365,14 @@ thermal_object_log_status(const thermal_object_t *self)
     }
     int temperature = thermal_object_get_temperature(self);
 
-    dsme_log(LOG_DEBUG, PFIX"%s: %dC %s", thermal_object_get_name(self),
+    dsme_log(LOG_DEBUG, PFIX "%s: %dC %s", thermal_object_get_name(self),
              temperature, thermal_status_name(self->to_status_curr));
 
     if( !did_open ) {
         did_open = true;
 
         if( !(log_file = fopen(log_path, "a")) ) {
-            dsme_log(LOG_ERR, PFIX"%s: Error opening thermal log: %m",
+            dsme_log(LOG_ERR, PFIX "%s: Error opening thermal log: %m",
                      log_path);
         }
     }
@@ -483,7 +483,7 @@ thermal_object_request_update(thermal_object_t *self)
     /* Skip if request has already been passed to lower level
      */
     if( self->to_request_pending ) {
-        dsme_log(LOG_DEBUG, PFIX"%s: still waiting for temperature",
+        dsme_log(LOG_DEBUG, PFIX "%s: still waiting for temperature",
                  thermal_object_get_name(self));
         goto EXIT;
     }
@@ -494,7 +494,7 @@ thermal_object_request_update(thermal_object_t *self)
      */
     self->to_request_pending = true, success = false;
 
-    dsme_log(LOG_DEBUG, PFIX"%s: requesting temperature",
+    dsme_log(LOG_DEBUG, PFIX "%s: requesting temperature",
              thermal_object_get_name(self));
 
     const char *depends_on = thermal_object_get_depends_on(self);
@@ -517,7 +517,7 @@ EXIT:
      * logic immediately */
 
     if( !success ) {
-        dsme_log(LOG_ERR, PFIX"%s: error requesting temperature",
+        dsme_log(LOG_ERR, PFIX "%s: error requesting temperature",
                  thermal_object_get_name(self));
         thermal_object_handle_update(self);
     }
@@ -562,7 +562,7 @@ thermal_object_handle_update(thermal_object_t *self)
 
     /* Get sensor status from sensor backend */
     if( !thermal_object_get_sensor_status(self, &status, &temperature) ) {
-        dsme_log(LOG_DEBUG, PFIX"%s: temperature request failed",
+        dsme_log(LOG_DEBUG, PFIX "%s: temperature request failed",
                  thermal_object_get_name(self));
         goto EXIT;
     }
@@ -571,13 +571,13 @@ thermal_object_handle_update(thermal_object_t *self)
      * and we drop obviously wrong values
      */
     if( temperature < IGNORE_TEMP_BELOW || temperature > IGNORE_TEMP_ABOVE ) {
-        dsme_log(LOG_WARNING, PFIX"%s: invalid temperature reading: %dC",
+        dsme_log(LOG_WARNING, PFIX "%s: invalid temperature reading: %dC",
                  thermal_object_get_name(self),
                  temperature);
         goto EXIT;
     }
 
-    dsme_log(LOG_DEBUG, PFIX"%s: temperature=%d status=%s",
+    dsme_log(LOG_DEBUG, PFIX "%s: temperature=%d status=%s",
              thermal_object_get_name(self),
              temperature,
              thermal_status_repr(status));
@@ -592,7 +592,7 @@ thermal_object_handle_update(thermal_object_t *self)
      */
     if( self->to_status_curr == status ) {
         if( self->to_status_next != status )
-            dsme_log(LOG_NOTICE, PFIX"%s: transition to status=%s %s at temperature=%d",
+            dsme_log(LOG_NOTICE, PFIX "%s: transition to status=%s %s at temperature=%d",
                      thermal_object_get_name(self),
                      thermal_status_repr(self->to_status_next),
                      "canceled",
@@ -614,7 +614,7 @@ thermal_object_handle_update(thermal_object_t *self)
         self->to_status_next = status;
         self->to_status_change_started = now;
 
-        dsme_log(LOG_NOTICE, PFIX"%s: transition to status=%s %s at temperature=%d",
+        dsme_log(LOG_NOTICE, PFIX "%s: transition to status=%s %s at temperature=%d",
                  thermal_object_get_name(self),
                  thermal_status_repr(self->to_status_next),
                  "started",
@@ -626,7 +626,7 @@ thermal_object_handle_update(thermal_object_t *self)
                     THERMAL_STATUS_TRANSITION_DELAY);
 
     if( now <= limit ) {
-            dsme_log(LOG_NOTICE, PFIX"%s: transition to status=%s %s at temperature=%d",
+            dsme_log(LOG_NOTICE, PFIX "%s: transition to status=%s %s at temperature=%d",
                      thermal_object_get_name(self),
                      thermal_status_repr(self->to_status_next),
                      "pending",
@@ -636,7 +636,7 @@ thermal_object_handle_update(thermal_object_t *self)
 
     /* The new status stayed active long enough, better believe it */
 
-    dsme_log(LOG_NOTICE, PFIX"%s: transition to status=%s %s at temperature=%d",
+    dsme_log(LOG_NOTICE, PFIX "%s: transition to status=%s %s at temperature=%d",
              thermal_object_get_name(self),
              thermal_status_repr(self->to_status_next),
              "accepted",

--- a/modules/thermalsensor_generic.c
+++ b/modules/thermalsensor_generic.c
@@ -615,19 +615,19 @@ thermal_sensor_generic_is_valid(thermal_sensor_generic_t *self)
         goto EXIT;
 
     if( !self->sg_name ) {
-        dsme_log(LOG_ERR, PFIX"sensor object without a name");
+        dsme_log(LOG_ERR, PFIX "sensor object without a name");
         goto EXIT;
     }
 
     if( !self->sg_temp_cb ) {
-        dsme_log(LOG_ERR, PFIX"%s: %s",
+        dsme_log(LOG_ERR, PFIX "%s: %s",
                  thermal_sensor_generic_get_name(self),
                  "no temperature callback defined");
         goto EXIT;
     }
 
     if( !self->sg_temp_path ) {
-        dsme_log(LOG_ERR, PFIX"%s: %s",
+        dsme_log(LOG_ERR, PFIX "%s: %s",
                  thermal_sensor_generic_get_name(self),
                  "no temperature source defined");
         goto EXIT;
@@ -635,28 +635,28 @@ thermal_sensor_generic_is_valid(thermal_sensor_generic_t *self)
 
     if( !self->sg_is_meta &&
         access(self->sg_temp_path, R_OK) != 0 ) {
-        dsme_log(LOG_ERR, PFIX"%s: %s: %m",
+        dsme_log(LOG_ERR, PFIX "%s: %s: %m",
                  thermal_sensor_generic_get_name(self), self->sg_temp_path);
         goto EXIT;
     }
 
     if( self->sg_mode_path ) {
         if( self->sg_is_meta ) {
-            dsme_log(LOG_ERR, PFIX"%s: %s",
+            dsme_log(LOG_ERR, PFIX "%s: %s",
                      thermal_sensor_generic_get_name(self),
                      "mode control file specified for meta sensor");
             goto EXIT;
         }
 
         if( access(self->sg_mode_path, W_OK) != 0 ) {
-            dsme_log(LOG_ERR, PFIX"%s: %s: %m",
+            dsme_log(LOG_ERR, PFIX "%s: %s: %m",
                      thermal_sensor_generic_get_name(self),
                      self->sg_mode_path);
             goto EXIT;
         }
 
         if( !self->sg_mode_enable ) {
-            dsme_log(LOG_ERR, PFIX"%s: %s",
+            dsme_log(LOG_ERR, PFIX "%s: %s",
                      thermal_sensor_generic_get_name(self),
                      "enable value not defined");
             goto EXIT;
@@ -669,7 +669,7 @@ thermal_sensor_generic_is_valid(thermal_sensor_generic_t *self)
 
     for( int i = 0; i < THERMAL_STATUS_COUNT; ++i ) {
         if( self->sg_level[i].sl_mintemp == INVALID_TEMPERATURE ) {
-            dsme_log(LOG_ERR, PFIX"%s: %s",
+            dsme_log(LOG_ERR, PFIX "%s: %s",
                      thermal_sensor_generic_get_name(self),
                      "temperature limits not defined");
             goto EXIT;
@@ -677,7 +677,7 @@ thermal_sensor_generic_is_valid(thermal_sensor_generic_t *self)
         if( self->sg_level[i].sl_minwait < 1 ||
             self->sg_level[i].sl_maxwait < 5 ||
             self->sg_level[i].sl_maxwait < self->sg_level[i].sl_minwait ) {
-            dsme_log(LOG_ERR, PFIX"%s: %s",
+            dsme_log(LOG_ERR, PFIX "%s: %s",
                      thermal_sensor_generic_get_name(self),
                      "invalid wait period defined");
             goto EXIT;
@@ -686,7 +686,7 @@ thermal_sensor_generic_is_valid(thermal_sensor_generic_t *self)
 
     for( int i = 1; i < THERMAL_STATUS_COUNT; ++i ) {
         if( self->sg_level[i-1].sl_mintemp > self->sg_level[i].sl_mintemp ) {
-            dsme_log(LOG_ERR, PFIX"%s: %s",
+            dsme_log(LOG_ERR, PFIX "%s: %s",
                      thermal_sensor_generic_get_name(self),
                      "temperature limits not ascending");
             goto EXIT;
@@ -818,7 +818,7 @@ thermal_sensor_generic_sensor_is_enabled(const thermal_sensor_generic_t *self)
     is_enabled = false;
 
     if( !(mode = tsg_util_read_file(self->sg_mode_path)) ) {
-        dsme_log(LOG_WARNING, PFIX"%s: failed to read sensor mode: %m",
+        dsme_log(LOG_WARNING, PFIX "%s: failed to read sensor mode: %m",
                  thermal_sensor_generic_get_name(self));
         goto EXIT;
     }
@@ -865,22 +865,22 @@ thermal_sensor_generic_read_sensor(thermal_sensor_generic_t *self)
 
         /* Attempt to re-enale and read again */
 
-        dsme_log(LOG_WARNING, PFIX"%s: sensor is disabled; re-enabling",
+        dsme_log(LOG_WARNING, PFIX "%s: sensor is disabled; re-enabling",
                  thermal_sensor_generic_get_name(self));
 
         if( !thermal_sensor_generic_enable_sensor(self, true) ) {
-            dsme_log(LOG_WARNING, PFIX"%s: enabling failed",
+            dsme_log(LOG_WARNING, PFIX "%s: enabling failed",
                      thermal_sensor_generic_get_name(self));
             goto EXIT;
         }
 
         if( !self->sg_temp_cb(self->sg_temp_path, &temp) ) {
-            dsme_log(LOG_WARNING, PFIX"%s: reading still failed",
+            dsme_log(LOG_WARNING, PFIX "%s: reading still failed",
                      thermal_sensor_generic_get_name(self));
             goto EXIT;
         }
 
-        dsme_log(LOG_DEBUG, PFIX"%s: succesfully re-enabled",
+        dsme_log(LOG_DEBUG, PFIX "%s: succesfully re-enabled",
                  thermal_sensor_generic_get_name(self));
     }
 
@@ -1251,17 +1251,17 @@ tsg_objects_register_all(GSList **list)
             continue;
 
         if( !thermal_sensor_generic_is_valid(sensor) ) {
-            dsme_log(LOG_ERR, PFIX"%s: %s",
+            dsme_log(LOG_ERR, PFIX "%s: %s",
                      thermal_sensor_generic_get_name(sensor),
                      "sensor config is not valid");
         }
         else if( !thermal_sensor_generic_enable_sensor(sensor, true) ) {
-            dsme_log(LOG_ERR, PFIX"%s: %s",
+            dsme_log(LOG_ERR, PFIX "%s: %s",
                      thermal_sensor_generic_get_name(sensor),
                      "sensor could not be enabled");
         }
         else if( !thermal_sensor_generic_read_sensor(sensor) ) {
-            dsme_log(LOG_ERR, PFIX"%s: %s",
+            dsme_log(LOG_ERR, PFIX "%s: %s",
                      thermal_sensor_generic_get_name(sensor),
                      "sensor could not be read");
         }
@@ -1351,7 +1351,7 @@ tsg_objects_read_config(GSList **list, const char *config)
             sensor = tsg_objects_add_sensor(list, tsg_util_slice_str(&pos));
         }
         else if( !sensor ) {
-            dsme_log(LOG_ERR, PFIX"%s:%d: stray configuration item: %s",
+            dsme_log(LOG_ERR, PFIX "%s:%d: stray configuration item: %s",
                      config, line, key);
         }
         else if( !strcmp(key, CONFIG_KW_TEMP) ) {
@@ -1376,7 +1376,7 @@ tsg_objects_read_config(GSList **list, const char *config)
                                                      tsg_util_read_temp_mC);
             }
             else {
-                dsme_log(LOG_ERR, PFIX"%s:%d: unknown/missing temp type: %s",
+                dsme_log(LOG_ERR, PFIX "%s:%d: unknown/missing temp type: %s",
                          config, line, type);
                 thermal_sensor_generic_set_temp_func(sensor, 0);
             }
@@ -1405,7 +1405,7 @@ tsg_objects_read_config(GSList **list, const char *config)
                                              mintemp, minwait, maxwait);
         }
         else {
-            dsme_log(LOG_ERR, PFIX"%s:%d: unknown item: %s",
+            dsme_log(LOG_ERR, PFIX "%s:%d: unknown item: %s",
                      config, line, key);
             continue;
         }
@@ -1413,7 +1413,7 @@ tsg_objects_read_config(GSList **list, const char *config)
         /* Check if line contains unparsed elements */
         pos = tsg_util_slice_token(pos, 0, 0);
         if( *pos != 0 && *pos != '#' ) {
-            dsme_log(LOG_WARNING, PFIX"%s:%d: excess elements: %s",
+            dsme_log(LOG_WARNING, PFIX "%s:%d: excess elements: %s",
                      config, line, pos);
         }
     }
@@ -1456,7 +1456,7 @@ tsg_objects_init(GSList **list)
     glob_t gl = {};
 
     if( glob(pat, GLOB_ERR, 0, &gl) != 0 ) {
-        dsme_log(LOG_WARNING, PFIX"No thermal config files found");
+        dsme_log(LOG_WARNING, PFIX "No thermal config files found");
         goto EXIT;
     }
 
@@ -1486,7 +1486,7 @@ static GSList *objects_list = 0;
  */
 DSME_HANDLER(DSM_MSGTYPE_DBUS_CONNECTED, client, msg)
 {
-    dsme_log(LOG_DEBUG, PFIX"DBUS_CONNECTED");
+    dsme_log(LOG_DEBUG, PFIX "DBUS_CONNECTED");
     tsg_objects_init(&objects_list);
 }
 
@@ -1498,7 +1498,7 @@ DSME_HANDLER(DSM_MSGTYPE_DBUS_CONNECTED, client, msg)
  */
 DSME_HANDLER(DSM_MSGTYPE_DBUS_DISCONNECT, client, msg)
 {
-    dsme_log(LOG_DEBUG, PFIX"DBUS_DISCONNECT");
+    dsme_log(LOG_DEBUG, PFIX "DBUS_DISCONNECT");
     tsg_objects_quit(&objects_list);
 }
 
@@ -1519,7 +1519,7 @@ module_init(module_t *handle)
 {
     (void)handle;
 
-    dsme_log(LOG_DEBUG, PFIX"loaded");
+    dsme_log(LOG_DEBUG, PFIX "loaded");
 }
 
 /** Exit hook that DSME plugins need to implement
@@ -1528,5 +1528,5 @@ void
 module_fini(void)
 {
     tsg_objects_quit(&objects_list);
-    dsme_log(LOG_DEBUG, PFIX"unloaded");
+    dsme_log(LOG_DEBUG, PFIX "unloaded");
 }

--- a/modules/thermalsensor_generic.c
+++ b/modules/thermalsensor_generic.c
@@ -135,7 +135,6 @@ typedef struct
 
     /** Thermal level configuration array */
     sensor_level_t     sg_level[THERMAL_STATUS_COUNT];
-
 } thermal_sensor_generic_t;
 
 static thermal_sensor_generic_t  *thermal_sensor_generic_create             (const char *name);
@@ -412,7 +411,6 @@ tsg_util_write_file(const char *path, const char *text)
     ack = true;
 
 EXIT:
-
     if( file != -1 )
         TEMP_FAILURE_RETRY(close(file));
 
@@ -698,7 +696,6 @@ thermal_sensor_generic_is_valid(thermal_sensor_generic_t *self)
     is_valid = true;
 
 EXIT:
-
     return is_valid;
 }
 
@@ -860,7 +857,6 @@ thermal_sensor_generic_read_sensor(thermal_sensor_generic_t *self)
         goto EXIT;
 
     if( !self->sg_temp_cb(self->sg_temp_path, &temp) ) {
-
         /* Check if the failure could be because some other
          * process has disabled the sensor */
 
@@ -1446,7 +1442,6 @@ tsg_objects_quit(GSList **list)
     }
 
     g_slist_free(*list), *list = 0;
-
 }
 
 /** Create linked list of thermal objects based on config files

--- a/modules/upstart.c
+++ b/modules/upstart.c
@@ -54,12 +54,10 @@
 # endif
 #endif
 
-
 static bool save_state_for_getbootstate(dsme_runlevel_t runlevel);
 static bool telinit_internal(dsme_runlevel_t runlevel);
 static void shutdown_internal(dsme_runlevel_t runlevel);
 static bool remount_mmc_readonly(void);
-
 
 static int current_runlevel_in_utmp()
 {
@@ -134,7 +132,6 @@ static bool save_state_in_utmp_and_wtmp(dsme_runlevel_t runlevel)
 
     return saved;
 }
-
 
 static bool save_state_for_getbootstate(dsme_runlevel_t runlevel)
 {
@@ -300,7 +297,6 @@ static bool telinit_internal(dsme_runlevel_t runlevel)
         goto done;
     }
 
-
     // make the call
     // TODO: do not block!
     DBusMessage* reply;
@@ -327,7 +323,6 @@ static bool telinit_internal(dsme_runlevel_t runlevel)
 
     if (reply) dbus_message_unref(reply);
 
-
 done:
     if (call) dbus_message_unref(call);
     if (conn) {
@@ -338,7 +333,6 @@ done:
 
     return runlevel_changed;
 }
-
 
 /*
  * This function will do the shutdown or reboot (based on desired runlevel).
@@ -389,7 +383,6 @@ static void shutdown_internal(dsme_runlevel_t runlevel)
               }
           }
       }
-
   }
 
   return;
@@ -398,7 +391,6 @@ fail_and_exit:
   dsme_log(LOG_CRIT, "Closing to clean-up!");
   dsme_main_loop_quit(EXIT_FAILURE);
 }
-
 
 /*
  * This function tries to find mounted MMC (mmcblk) and remount it
@@ -466,13 +458,11 @@ static bool remount_mmc_readonly(void)
 
       dsme_log(LOG_NOTICE, "MMC remounted read-only");
       return true;
-
   } else {
       dsme_log(LOG_NOTICE, "MMC not mounted");
       return true;
   }
 }
-
 
 DSME_HANDLER(DSM_MSGTYPE_CHANGE_RUNLEVEL, conn, msg)
 {
@@ -484,13 +474,11 @@ DSME_HANDLER(DSM_MSGTYPE_SHUTDOWN, conn, msg)
   shutdown_internal(msg->runlevel);
 }
 
-
 module_fn_info_t message_handlers[] = {
   DSME_HANDLER_BINDING(DSM_MSGTYPE_CHANGE_RUNLEVEL),
   DSME_HANDLER_BINDING(DSM_MSGTYPE_SHUTDOWN),
   { 0 }
 };
-
 
 void module_init(module_t* module)
 {

--- a/modules/usbtracker.c
+++ b/modules/usbtracker.c
@@ -191,7 +191,7 @@ send_usb_status(bool mounted_to_pc)
 
     prev = msg.mounted_to_pc = mounted_to_pc;
 
-    dsme_log(LOG_DEBUG, PFIX"broadcasting usb state:%s mounted to PC",
+    dsme_log(LOG_DEBUG, PFIX "broadcasting usb state:%s mounted to PC",
              msg.mounted_to_pc ? "" : " not");
 
     modules_broadcast_internally(&msg);
@@ -232,7 +232,7 @@ evaluate_status(const char *mode, bool *is_charging, bool *is_mounted)
      * is included in the lookup table -> any unknown mode name is assumed
      * to mean that charging should be possible. */
 
-    dsme_log(LOG_INFO, "unknown usb mode '%s'; assuming charger-connected",
+    dsme_log(LOG_INFO, PFIX "unknown usb mode '%s'; assuming charger-connected",
              mode);
 
     charging = true;
@@ -250,7 +250,7 @@ cleanup:
 static void
 update_status(const char *mode)
 {
-    dsme_log(LOG_DEBUG, PFIX"mode = '%s'", mode ?: "unknown");
+    dsme_log(LOG_DEBUG, PFIX "mode = '%s'", mode ?: "unknown");
 
     /* Cancel waiting if we have status update for any reason */
     wait_for_usb_moded_cancel();
@@ -285,7 +285,7 @@ wait_for_usb_moded_cb(gpointer aptr)
      * act-dead, this can cause/allow the device to shutdown
      */
 
-    dsme_log(LOG_WARNING, PFIX"usb state unknown; assume: no charger");
+    dsme_log(LOG_WARNING, PFIX "usb state unknown; assume: no charger");
     update_status(0);
 
 cleanup:
@@ -297,7 +297,7 @@ static void
 wait_for_usb_moded_cancel(void)
 {
     if( wait_for_usb_moded_id ) {
-        dsme_log(LOG_DEBUG, PFIX"stop waiting for usb_moded");
+        dsme_log(LOG_DEBUG, PFIX "stop waiting for usb_moded");
         dsme_destroy_timer(wait_for_usb_moded_id),
             wait_for_usb_moded_id = 0;
     }
@@ -308,7 +308,7 @@ static void
 wait_for_usb_moded_start(void)
 {
     if( !wait_for_usb_moded_id ) {
-        dsme_log(LOG_DEBUG, PFIX"start waiting for usb_moded");
+        dsme_log(LOG_DEBUG, PFIX "start waiting for usb_moded");
         wait_for_usb_moded_id = dsme_create_timer(WAIT_FOR_USB_MODED_MS,
                                                   wait_for_usb_moded_cb, 0);
     }
@@ -350,7 +350,7 @@ xusbmoded_query_mode_cb(DBusPendingCall *pending, void *aptr)
                                DBUS_TYPE_STRING, &dta,
                                DBUS_TYPE_INVALID) )
     {
-        dsme_log(LOG_ERR, PFIX"mode_request reply: %s: %s",
+        dsme_log(LOG_ERR, PFIX "mode_request reply: %s: %s",
                  err.name, err.message);
         goto cleanup;
     }
@@ -399,11 +399,11 @@ xusbmoded_query_mode_async(void)
 
     res = true;
 
-    dsme_log(LOG_DEBUG, PFIX"mode_request sent");
+    dsme_log(LOG_DEBUG, PFIX "mode_request sent");
 
 cleanup:
     if( !res ) {
-        dsme_log(LOG_ERR, PFIX"mode_request failed; "
+        dsme_log(LOG_ERR, PFIX "mode_request failed; "
                  "waiting for signal / usb_moded restart");
 
         /* Wait a while before assuming charger is not connected */
@@ -430,7 +430,7 @@ xusbmoded_set_runstate(bool running)
 
     prev = running;
 
-    dsme_log(LOG_DEBUG, PFIX"usb_moded %s",  running ? "running" : "stopped");
+    dsme_log(LOG_DEBUG, PFIX "usb_moded %s",  running ? "running" : "stopped");
 
     if( running ) {
         /* Stop wait for service timer and query initial state */
@@ -457,7 +457,7 @@ xusbmoded_query_owner_cb(DBusPendingCall *pending, void *aptr)
 {
     (void) aptr; // not used
 
-    dsme_log(LOG_DEBUG, PFIX"usb_moded runstate reply");
+    dsme_log(LOG_DEBUG, PFIX "usb_moded runstate reply");
 
     const module_t *caller = modulebase_enter_module(this_module);
 
@@ -473,7 +473,7 @@ xusbmoded_query_owner_cb(DBusPendingCall *pending, void *aptr)
                                DBUS_TYPE_STRING, &dta,
                                DBUS_TYPE_INVALID) ) {
         if( strcmp(err.name, DBUS_ERROR_NAME_HAS_NO_OWNER) ) {
-            dsme_log(LOG_WARNING, PFIX"usb_moded name owner reply: %s: %s",
+            dsme_log(LOG_WARNING, PFIX "usb_moded name owner reply: %s: %s",
                      err.name, err.message);
         }
         goto cleanup;
@@ -495,7 +495,7 @@ cleanup:
 static bool
 xusbmoded_query_owner(void)
 {
-    dsme_log(LOG_DEBUG, PFIX"usb_moded runstate query");
+    dsme_log(LOG_DEBUG, PFIX "usb_moded runstate query");
 
     bool             res  = false;
     DBusMessage     *req  = 0;
@@ -580,13 +580,13 @@ xusbmoded_dbus_filter_cb(DBusConnection *con, DBusMessage *msg, void *aptr)
                                DBUS_TYPE_STRING, &prev,
                                DBUS_TYPE_STRING, &curr,
                                DBUS_TYPE_INVALID) ) {
-        dsme_log(LOG_WARNING, PFIX"usb_moded name owner signal: %s: %s",
+        dsme_log(LOG_WARNING, PFIX "usb_moded name owner signal: %s: %s",
                  err.name, err.message);
         goto cleanup;
     }
 
     if( !strcmp(name, USB_MODED_DBUS_SERVICE) ) {
-        dsme_log(LOG_DEBUG, PFIX"usb_moded runstate changed");
+        dsme_log(LOG_DEBUG, PFIX "usb_moded runstate changed");
         xusbmoded_set_runstate(*curr != 0);
     }
 
@@ -659,7 +659,7 @@ systembus_connect(void)
     DBusError err = DBUS_ERROR_INIT;
 
     if( !(systembus = dsme_dbus_get_connection(&err)) ) {
-        dsme_log(LOG_WARNING, PFIX"can't connect to systembus: %s: %s",
+        dsme_log(LOG_WARNING, PFIX "can't connect to systembus: %s: %s",
                  err.name, err.message);
         goto cleanup;
     }
@@ -698,14 +698,14 @@ static bool dbus_signals_bound = false;
 
 DSME_HANDLER(DSM_MSGTYPE_DBUS_CONNECTED, client, msg)
 {
-    dsme_log(LOG_DEBUG, PFIX"DBUS_CONNECTED");
+    dsme_log(LOG_DEBUG, PFIX "DBUS_CONNECTED");
     dsme_dbus_bind_signals(&dbus_signals_bound, dbus_signals_array);
     systembus_connect();
 }
 
 DSME_HANDLER(DSM_MSGTYPE_DBUS_DISCONNECT, client, msg)
 {
-    dsme_log(LOG_DEBUG, PFIX"DBUS_DISCONNECT");
+    dsme_log(LOG_DEBUG, PFIX "DBUS_DISCONNECT");
     systembus_disconnect();
 }
 
@@ -727,7 +727,7 @@ void module_init(module_t* handle)
      * time, assume that charger is not connected */
     wait_for_usb_moded_start();
 
-    dsme_log(LOG_DEBUG, "usbtracker.so loaded");
+    dsme_log(LOG_DEBUG, PFIX "usbtracker.so loaded");
 }
 
 void module_fini(void)
@@ -737,5 +737,5 @@ void module_fini(void)
     /* Remove timers */
     wait_for_usb_moded_cancel();
 
-    dsme_log(LOG_DEBUG, "usbtracker.so unloaded");
+    dsme_log(LOG_DEBUG, PFIX "usbtracker.so unloaded");
 }

--- a/modules/usbtracker.c
+++ b/modules/usbtracker.c
@@ -197,7 +197,6 @@ send_usb_status(bool mounted_to_pc)
     modules_broadcast_internally(&msg);
 
 cleanup:
-
     return;
 }
 
@@ -240,7 +239,6 @@ evaluate_status(const char *mode, bool *is_charging, bool *is_mounted)
     mounted  = false;
 
 cleanup:
-
     *is_charging = charging;
     *is_mounted  = mounted;
 
@@ -291,7 +289,6 @@ wait_for_usb_moded_cb(gpointer aptr)
     update_status(0);
 
 cleanup:
-
     return FALSE;
 }
 
@@ -359,7 +356,6 @@ xusbmoded_query_mode_cb(DBusPendingCall *pending, void *aptr)
     }
 
 cleanup:
-
     /* Update state; any errors above yield not-connected, not-mounted */
     update_status(dta);
 
@@ -406,7 +402,6 @@ xusbmoded_query_mode_async(void)
     dsme_log(LOG_DEBUG, PFIX"mode_request sent");
 
 cleanup:
-
     if( !res ) {
         dsme_log(LOG_ERR, PFIX"mode_request failed; "
                  "waiting for signal / usb_moded restart");
@@ -449,7 +444,6 @@ xusbmoded_set_runstate(bool running)
     }
 
 cleanup:
-
     return;
 }
 
@@ -486,7 +480,6 @@ xusbmoded_query_owner_cb(DBusPendingCall *pending, void *aptr)
     }
 
 cleanup:
-
     xusbmoded_set_runstate(dta && *dta);
 
     if( rsp ) dbus_message_unref(rsp);
@@ -536,7 +529,6 @@ xusbmoded_query_owner(void)
     res = true;
 
 cleanup:
-
     if( pc  ) dbus_pending_call_unref(pc);
     if( req ) dbus_message_unref(req);
 
@@ -599,7 +591,6 @@ xusbmoded_dbus_filter_cb(DBusConnection *con, DBusMessage *msg, void *aptr)
     }
 
 cleanup:
-
     dbus_error_free(&err);
 
     modulebase_enter_module(caller);
@@ -633,7 +624,6 @@ xusbmoded_init_tracking(void)
     xusbmoded_query_owner();
 
 cleanup:
-
     return;
 }
 
@@ -652,7 +642,6 @@ xusbmoded_quit_tracking(void)
     dbus_connection_remove_filter(systembus, xusbmoded_dbus_filter_cb, 0);
 
 cleanup:
-
     return;
 }
 
@@ -678,7 +667,6 @@ systembus_connect(void)
     xusbmoded_init_tracking();
 
 cleanup:
-
     dbus_error_free(&err);
 }
 
@@ -713,7 +701,6 @@ DSME_HANDLER(DSM_MSGTYPE_DBUS_CONNECTED, client, msg)
     dsme_log(LOG_DEBUG, PFIX"DBUS_CONNECTED");
     dsme_dbus_bind_signals(&dbus_signals_bound, dbus_signals_array);
     systembus_connect();
-
 }
 
 DSME_HANDLER(DSM_MSGTYPE_DBUS_DISCONNECT, client, msg)

--- a/modules/validatorlistener.c
+++ b/modules/validatorlistener.c
@@ -50,7 +50,6 @@
 
 #define DSME_STATIC_STRLEN(s) (sizeof(s) - 1)
 
-
 // TODO: try to find a header that #defines NETLINK_VALIDATOR
 //       and possibly the right group mask to use
 #ifndef NETLINK_VALIDATOR
@@ -63,12 +62,10 @@
 #define DSME_CONFIG_VALIDATED_PATH   "/etc/init.conf"
 #define DSME_CONFIG_VALIDATED_PREFIX "mandatorybinary "
 
-
 static void stop_listening_to_validator(void);
 static bool read_mandatory_file_list(const char* config_path, GSList** files);
 static bool is_in_list(const char* file, GSList* list);
 static bool is_basename_in_list(const char* file, GSList* list);
-
 
 /** Cached module handle for this plugin */
 static const module_t *this_module = 0;
@@ -89,7 +86,6 @@ static void go_to_malf(const char* component, const char* details)
 
     modules_broadcast_internally_with_extra(&malf, strlen(details) + 1, details);
 }
-
 
 // parse a line of format "<key>: <text>"
 static bool parse_validator_line(const char** msg, char** key, char** text)
@@ -180,7 +176,6 @@ static bool check_security_malf(int vreason, char* component, char* details)
     // a list of mandatory files exists; check against it
     if (is_in_list(details, mandatory_files) ||
         is_basename_in_list(component, mandatory_files)) {
-
         // this file was on the list => MALF if the validation failed
         // because of anything else than a missing reference hash
         if (vreason != VREASON_HLIST) {
@@ -203,7 +198,6 @@ static gboolean handle_validator_message(GIOChannel*  source,
     bool keep_listening = true;
 
     if (condition & G_IO_IN) {
-
         struct sockaddr_nl addr;
         memset(&addr, 0, sizeof(addr));
 
@@ -225,7 +219,6 @@ static gboolean handle_validator_message(GIOChannel*  source,
         msg.msg_namelen = sizeof(addr);
         msg.msg_iov     = &iov;
         msg.msg_iovlen  = 1;
-
 
         int fd = g_io_channel_unix_get_fd(source);
         int r = TEMP_FAILURE_RETRY(recvmsg(fd, &msg, 0));
@@ -277,7 +270,6 @@ static gboolean handle_validator_message(GIOChannel*  source,
     return keep_listening;
 }
 
-
 static bool start_listening_to_validator(void)
 {
     int         fd  = -1;
@@ -312,6 +304,7 @@ static bool start_listening_to_validator(void)
     validator_id = g_io_add_watch(chn,
                                   G_IO_IN | G_IO_ERR | G_IO_HUP | G_IO_NVAL,
                                   handle_validator_message, 0);
+
 cleanup:
     if( chn )
         g_io_channel_unref(chn);

--- a/modules/vibrafeedback.c
+++ b/modules/vibrafeedback.c
@@ -53,10 +53,10 @@ static void ngf_callback(NgfClient *client, uint32_t id, NgfEventState state, vo
 
 static void create_ngf_client(void)
 {
-    //dsme_log(LOG_DEBUG, PFIX"%s()", __FUNCTION__);
+    //dsme_log(LOG_DEBUG, PFIX "%s()", __FUNCTION__);
 
     if (ngf_client) {
-        dsme_log(LOG_DEBUG, PFIX"%s() %s", __FUNCTION__, "We already have a connection");
+        dsme_log(LOG_DEBUG, PFIX "%s() %s", __FUNCTION__, "We already have a connection");
         return;
     }
 
@@ -64,12 +64,12 @@ static void create_ngf_client(void)
         dsme_ini_vibrafeedback();
     }
     if (!dbus_connection) {
-        dsme_log(LOG_WARNING, PFIX"No dbus connection. Can't connect to ngf");
+        dsme_log(LOG_WARNING, PFIX "No dbus connection. Can't connect to ngf");
         return;
     }
 
     if ((ngf_client = ngf_client_create(NGF_TRANSPORT_DBUS, dbus_connection)) == NULL) {
-        dsme_log(LOG_ERR, PFIX"Can't create ngf client");
+        dsme_log(LOG_ERR, PFIX "Can't create ngf client");
     } else {
         ngf_client_set_callback(ngf_client, ngf_callback, NULL);
     }
@@ -77,7 +77,7 @@ static void create_ngf_client(void)
 
 static void destroy_ngf_client(void)
 {
-    //dsme_log(LOG_DEBUG, PFIX"%s()", __FUNCTION__);
+    //dsme_log(LOG_DEBUG, PFIX "%s()", __FUNCTION__);
     if (ngf_client) {
         ngf_client_destroy(ngf_client);
         ngf_client = NULL;
@@ -96,7 +96,7 @@ ngf_callback(NgfClient *client, uint32_t event_id, NgfEventState state, void *us
     switch (state) {
         case NGF_EVENT_FAILED:
             state_name = "Failed";
-            dsme_log(LOG_ERR, PFIX"Failed to play id %d", event_id);
+            dsme_log(LOG_ERR, PFIX "Failed to play id %d", event_id);
             play_done = true;
             break;
         case NGF_EVENT_COMPLETED:
@@ -112,7 +112,7 @@ ngf_callback(NgfClient *client, uint32_t event_id, NgfEventState state, void *us
             play_done = true;
             break;
     }
-    dsme_log(LOG_DEBUG, PFIX"%s(%s, %d)", __FUNCTION__, state_name, event_id);
+    dsme_log(LOG_DEBUG, PFIX "%s(%s, %d)", __FUNCTION__, state_name, event_id);
 
     if (play_done) {
         playing_event_id = 0;
@@ -123,7 +123,7 @@ void dsme_play_vibra(const char *event_name)
 {
     if (playing_event_id) {
         /* We already are playing an event, don't start new one */
-        dsme_log(LOG_DEBUG, PFIX"Play already going, skip");
+        dsme_log(LOG_DEBUG, PFIX "Play already going, skip");
         return;
     }
 
@@ -131,21 +131,21 @@ void dsme_play_vibra(const char *event_name)
         create_ngf_client();
     }
     if (!ngf_client) {
-        dsme_log(LOG_ERR, PFIX"Can't play vibra. We don't have ngf client");
+        dsme_log(LOG_ERR, PFIX "Can't play vibra. We don't have ngf client");
         return;
     }
 
     playing_event_id = ngf_client_play_event (ngf_client, event_name, NULL);
-    dsme_log(LOG_DEBUG, PFIX"PLAY(%s, %d)", event_name, playing_event_id);
+    dsme_log(LOG_DEBUG, PFIX "PLAY(%s, %d)", event_name, playing_event_id);
 }
 
 void dsme_ini_vibrafeedback(void)
 {
     DBusError err = DBUS_ERROR_INIT;
 
-    dsme_log(LOG_DEBUG, PFIX"%s()", __FUNCTION__);
+    dsme_log(LOG_DEBUG, PFIX "%s()", __FUNCTION__);
     if (!(dbus_connection = dsme_dbus_get_connection(&err))) {
-        dsme_log(LOG_WARNING, PFIX"can't connect to systembus: %s: %s",
+        dsme_log(LOG_WARNING, PFIX "can't connect to systembus: %s: %s",
                  err.name, err.message);
         goto cleanup;
     }
@@ -156,7 +156,7 @@ cleanup:
 
 void dsme_fini_vibrafeedback(void)
 {
-    dsme_log(LOG_DEBUG, PFIX"%s()", __FUNCTION__);
+    dsme_log(LOG_DEBUG, PFIX "%s()", __FUNCTION__);
     destroy_ngf_client();
     if (dbus_connection) {
         dbus_connection_unref(dbus_connection);

--- a/modules/vibrafeedback.c
+++ b/modules/vibrafeedback.c
@@ -121,7 +121,6 @@ ngf_callback(NgfClient *client, uint32_t event_id, NgfEventState state, void *us
 
 void dsme_play_vibra(const char *event_name)
 {
-
     if (playing_event_id) {
         /* We already are playing an event, don't start new one */
         dsme_log(LOG_DEBUG, PFIX"Play already going, skip");
@@ -140,8 +139,8 @@ void dsme_play_vibra(const char *event_name)
     dsme_log(LOG_DEBUG, PFIX"PLAY(%s, %d)", event_name, playing_event_id);
 }
 
-void dsme_ini_vibrafeedback(void) {
-
+void dsme_ini_vibrafeedback(void)
+{
     DBusError err = DBUS_ERROR_INIT;
 
     dsme_log(LOG_DEBUG, PFIX"%s()", __FUNCTION__);
@@ -150,12 +149,13 @@ void dsme_ini_vibrafeedback(void) {
                  err.name, err.message);
         goto cleanup;
     }
+
 cleanup:
     dbus_error_free(&err);
 }
 
-void dsme_fini_vibrafeedback(void) {
-
+void dsme_fini_vibrafeedback(void)
+{
     dsme_log(LOG_DEBUG, PFIX"%s()", __FUNCTION__);
     destroy_ngf_client();
     if (dbus_connection) {

--- a/modules/wlanloader.c
+++ b/modules/wlanloader.c
@@ -84,7 +84,6 @@ static void reset_wlan_module(void)
         goto cleanup;
 
 cleanup:
-
     if (req) dbus_message_unref(req);
     if (conn) dbus_connection_unref(conn);
     dbus_error_free(&err);
@@ -182,7 +181,6 @@ static void check_loader_needed(void)
         goto cleanup;
 
 cleanup:
-
     if (pc) dbus_pending_call_unref(pc);
     if (req) dbus_message_unref(req);
     if (conn) dbus_connection_unref(conn);
@@ -220,4 +218,3 @@ module_fini(void)
     dsme_dbus_unbind_signals(&dbus_signals_bound, dbus_signals_array);
     dsme_log(LOG_DEBUG, "libwlanloader.so unloaded");
 }
-

--- a/modules/wlanloader.c
+++ b/modules/wlanloader.c
@@ -45,6 +45,8 @@
 #include "../include/dsme/logging.h"
 #include "../include/dsme/modulebase.h"
 
+#define PFIX "wlanloader: "
+
 #define WLAN_SYSTEMD_UNIT   "wlan-module-load.service"
 
 static module_t *this_module = 0;
@@ -57,11 +59,11 @@ static void reset_wlan_module(void)
     const char      *unit = WLAN_SYSTEMD_UNIT;
     const char      *mode = "ignore-requirements";
 
-    dsme_log(LOG_DEBUG, "wlanloader: Resetting WLAN");
+    dsme_log(LOG_DEBUG, PFIX "wlanloader: Resetting WLAN");
 
     if (!(conn = dsme_dbus_get_connection(&err)))
     {
-	dsme_log(LOG_ERR, "wlanloader: system bus connect: %s: %s",
+	dsme_log(LOG_ERR, PFIX "wlanloader: system bus connect: %s: %s",
 		 err.name, err.message);
         goto cleanup;
     }
@@ -98,7 +100,7 @@ static void connman_tethering_changed(const DsmeDbusMessage* sig)
                             "/net/connman/technology/wifi") == 0)
     {
         tethering = dsme_dbus_message_get_variant_bool(sig);
-        dsme_log(LOG_DEBUG, "wlanloader: Tethering status changed to %d",
+        dsme_log(LOG_DEBUG, PFIX "wlanloader: Tethering status changed to %d",
                                          tethering);
 
         if (!tethering) {
@@ -125,14 +127,14 @@ static void loader_needed_cb(DBusPendingCall *pending, void *user_data)
         goto cleanup;
 
     if (dbus_set_error_from_message(&err, rsp)) {
-        dsme_log(LOG_DEBUG, "wlanloader: disabled, GetUnit: %s: %s",
+        dsme_log(LOG_DEBUG, PFIX "wlanloader: disabled, GetUnit: %s: %s",
                                                     err.name, err.message);
     } else {
         /* We got the reply without error, so the service exists */
         const module_t *restore = modulebase_enter_module(this_module);
         dsme_dbus_bind_signals(&dbus_signals_bound, dbus_signals_array);
         modulebase_enter_module(restore);
-        dsme_log(LOG_DEBUG, "wlanloader: activated");
+        dsme_log(LOG_DEBUG, PFIX "wlanloader: activated");
     }
 
 cleanup:
@@ -151,7 +153,7 @@ static void check_loader_needed(void)
 
     if (!(conn = dsme_dbus_get_connection(&err)))
     {
-	dsme_log(LOG_ERR, "wlanloader: system bus connect: %s: %s",
+	dsme_log(LOG_ERR, PFIX "wlanloader: system bus connect: %s: %s",
 		 err.name, err.message);
         goto cleanup;
     }
@@ -173,7 +175,7 @@ static void check_loader_needed(void)
         goto cleanup;
 
     if (!pc) {
-        dsme_log(LOG_WARNING, "wlanloader: null pending call received");
+        dsme_log(LOG_WARNING, PFIX "wlanloader: null pending call received");
         goto cleanup;
     }
 
@@ -189,14 +191,14 @@ cleanup:
 
 DSME_HANDLER(DSM_MSGTYPE_DBUS_CONNECTED, client, msg)
 {
-    dsme_log(LOG_DEBUG, "wlanloader: DBUS_CONNECTED");
+    dsme_log(LOG_DEBUG, PFIX "wlanloader: DBUS_CONNECTED");
 
     check_loader_needed();
 }
 
 DSME_HANDLER(DSM_MSGTYPE_DBUS_DISCONNECT, client, msg)
 {
-    dsme_log(LOG_DEBUG, "wlanloader: DBUS_DISCONNECT");
+    dsme_log(LOG_DEBUG, PFIX "wlanloader: DBUS_DISCONNECT");
 }
 
 module_fn_info_t message_handlers[] = {
@@ -209,12 +211,12 @@ void
 module_init(module_t * handle)
 {
     this_module = handle;
-    dsme_log(LOG_DEBUG, "wlanloader.so loaded");
+    dsme_log(LOG_DEBUG, PFIX "wlanloader.so loaded");
 }
 
 void
 module_fini(void)
 {
     dsme_dbus_unbind_signals(&dbus_signals_bound, dbus_signals_array);
-    dsme_log(LOG_DEBUG, "libwlanloader.so unloaded");
+    dsme_log(LOG_DEBUG, PFIX "libwlanloader.so unloaded");
 }

--- a/rpm/dsme.spec
+++ b/rpm/dsme.spec
@@ -9,14 +9,14 @@ Source1:    dsme.service.in
 Source2:    dsme-rpmlintrc
 Requires:   systemd
 Requires:   ngfd
-Requires:   libdsme >= 0.66.0
+Requires:   libdsme >= 0.67.0
 Requires(preun): systemd
 Requires(post): systemd
 Requires(postun): systemd
 BuildRequires:  pkgconfig(glib-2.0) >= 2.32.0
 BuildRequires:  pkgconfig(dbus-1) >= 1.8
 BuildRequires:  pkgconfig(libiphb) >= 1.2.0
-BuildRequires:  pkgconfig(dsme) >= 0.66.0
+BuildRequires:  pkgconfig(dsme) >= 0.67.0
 BuildRequires:  pkgconfig(libsystemd)
 BuildRequires:  pkgconfig(mce) >= 1.12.3
 BuildRequires:  pkgconfig(libngf0) >= 0.24

--- a/rpm/dsme.spec
+++ b/rpm/dsme.spec
@@ -3,7 +3,7 @@ Summary:    Device State Management Entity
 Version:    0.84.2
 Release:    0
 License:    LGPLv2+
-URL:        https://git.sailfishos.org/mer-core/dsme
+URL:        https://github.com/sailfishos/dsme
 Source0:    %{name}-%{version}.tar.gz
 Source1:    dsme.service.in
 Source2:    dsme-rpmlintrc
@@ -62,7 +62,6 @@ test -e Makefile || (%configure --disable-static \
 %make_build _LIBDIR=%{_libdir}
 
 %install
-rm -rf %{buildroot}
 %make_install _LIBDIR=%{_libdir}
 
 install -d %{buildroot}%{_sysconfdir}/dsme/
@@ -88,7 +87,6 @@ systemctl reload-or-try-restart %{name}.service || :
 systemctl daemon-reload || :
 
 %files
-%defattr(-,root,root,-)
 %dir %{_libdir}/dsme
 %{_libdir}/dsme/*
 %attr(755,root,root)%{_sbindir}/*
@@ -103,11 +101,9 @@ systemctl daemon-reload || :
 /usr/lib/startup/preinit/set_system_time
 
 %files plugin-devel
-%defattr(-,root,root,-)
 %dir %{_includedir}/dsme-plugin
 %{_includedir}/dsme-plugin/*.h
 %{_libdir}/pkgconfig/dsme-plugin.pc
 
 %files tests
-%defattr(-,root,root,-)
 /opt/tests/dsme-tests

--- a/test/abnormalexitwrapper.c
+++ b/test/abnormalexitwrapper.c
@@ -49,7 +49,6 @@ void __attribute__ ((constructor)) my_init(void)
   signal(SIGUSR2, usr2_handler);
 }
 
-
 pid_t fork(void)
 {
   pid_t return_code = -1;
@@ -89,4 +88,3 @@ DBusConnection* dbus_connection_open_private(
 
   return conn;
 }
-

--- a/test/abnormalexitwrapper_tester.c
+++ b/test/abnormalexitwrapper_tester.c
@@ -36,7 +36,6 @@ void usr1_handler(int signum)
   waiting = 0;
 }
 
-
 int main()
 {
   printf("\nForkwrapper tester\n");

--- a/test/dsmetest.c
+++ b/test/dsmetest.c
@@ -60,7 +60,6 @@ void usage(const char *name)
 	printf("	-a --alarm			Change alarm state (0 = not set, 1 = set)\n");
 	printf("	-M --malf			Request MALF state\n");
         printf("	-h --help			Print usage\n");
-
 }
 
 void send_shutdown_req(bool battlow)
@@ -110,7 +109,7 @@ void send_malf_req(void)
   DSM_MSGTYPE_ENTER_MALF msg = DSME_MSG_INIT(DSM_MSGTYPE_ENTER_MALF);
   msg.reason = DSME_MALF_SOFTWARE;
   msg.component = NULL;
-  
+
   dsmesock_send_with_extra(conn, &msg, sizeof(details), details);
   printf("MALF request sent!\n");
 }

--- a/test/dummy_bme.c
+++ b/test/dummy_bme.c
@@ -38,7 +38,6 @@
 #include <poll.h>
 #include <sys/syslog.h>
 
-
 #define BME_SRV_SOCK_PATH       "/tmp/.bmesrv"
 #define BME_SRV_COOKIE          "BMentity"
 
@@ -49,14 +48,12 @@
 #define EM_BATTERY_INFO_REQ                      0x06
 #define EM_BATTERY_TEMP                          0x0004  /* -------------1-- */
 
-
 #define bme_log(L, FMT ...) fprintf(stderr, FMT);
 
 #include <sys/types.h>
 typedef struct {
     uint16_t      type, subtype;
 } tBMEmsgGeneric;
-
 
 struct emsg_battery_info_req {
     uint16_t      type, subtype;
@@ -84,12 +81,9 @@ union emsg_battery_info {
     struct emsg_battery_info_reply reply;
 };
 
-
 union bme_ext_messages {
     union emsg_battery_info battery_info;
-
 };
-
 
 enum {
     UMSD,
@@ -99,10 +93,8 @@ enum {
 
 static volatile sig_atomic_t sig_caught = 0;
 
-
 /* Client's socket descriptor that is in listening state */
 int umsfd = -1;
-
 
 /* Function prototypes */
 void bme_server_shutdown(void);
@@ -113,7 +105,6 @@ int bme_extmsg_handler(int client);
 int bme_reply_client(int client, int status, void *msg, int size);
 int bme_send_status_to_client(int client, int status);
 void bme_shutdown(void);
-
 
 /*
  * Initialize the server. Returns a negative value in case of failure.
@@ -157,7 +148,6 @@ int bme_server_init(void)
     return 0;
 }
 
-
 /*
  * Shut down the server
  */
@@ -168,7 +158,6 @@ void bme_server_shutdown(void)
 	umsfd = -1;
     }
 }
-
 
 /*
  * Handle new client. Returns client's new fd if connection was successful,
@@ -249,7 +238,6 @@ int bme_extmsg_handler(int client)
     return res;
 }
 
-
 /*
  * Reply to the client.
  * Status (32-bit value) is sent first, then reply message.
@@ -264,7 +252,6 @@ int bme_reply_client(int client, int status, void *msg, int size)
     return size;
 }
 
-
 /*
  * Send only a 32-bit status value to the client.
  */
@@ -272,7 +259,6 @@ int bme_send_status_to_client(int client, int status)
 {
     return write(client, &status, sizeof(status));
 }
-
 
 void bme_shutdown()
 {
@@ -299,7 +285,6 @@ int main(int argc, char *argv[])
     ufds[UMSD].events = POLLIN;
     ufds[CCSD].fd = -1;                 /* Connected client */
     ufds[CCSD].events = POLLIN;
-
 
     /*
      * Main loop. We poll socket descriptors, and call internal or external

--- a/test/processwdtest.c
+++ b/test/processwdtest.c
@@ -42,7 +42,6 @@
 
 #define CMDLINE DSME " -p libswwd.so"
 
-
 #ifdef STARTDSME
 static pid_t execdsme(void);
 static pid_t execdsme(void)
@@ -59,7 +58,6 @@ static pid_t execdsme(void)
   return pid;
 }
 #endif
-
 
 int dsmeprocesswdtest(int);
 int dsmeprocesswdtest(int testnum)
@@ -88,7 +86,7 @@ int dsmeprocesswdtest(int testnum)
       break;
     }
   }
-	
+
 	if (!conn) {
     tblog(testnum, TBLOG_ERROR, "Cannot connect to DSME\n");
     goto cleanup;
@@ -116,7 +114,7 @@ int dsmeprocesswdtest(int testnum)
 		curtime = time(NULL);
 		while (time(NULL) < curtime + 150) {
 			dsmemsg_generic_t * inmsg;
-			
+
 			inmsg = dsmesock_receive(conn);
 			if (inmsg) {
 				if (phase < 3) {
@@ -141,19 +139,19 @@ int dsmeprocesswdtest(int testnum)
 	/* Main process */
 	curtime = time(NULL);
 	while(waitpid(child, &status, 0) != child) ;
-	
+
 	if (time(NULL) < curtime + 27) {
 		tblog(testnum, TBLOG_ERROR, "Killed too early\n");
 		goto cleanup;
 	}
-	
+
 	if (time(NULL) > curtime + 150) {
 		tblog(testnum, TBLOG_ERROR, "Didn't get killed\n");
 		goto cleanup;
 	}
 
 	retval = 0;
-		
+
  cleanup:
 	if (conn) {
 		dsmesock_close(conn);

--- a/test/stub_cal.h
+++ b/test/stub_cal.h
@@ -22,7 +22,6 @@
    License along with Dsme.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DSME_TEST_STUB_CAL_H
 #define DSME_TEST_STUB_CAL_H
 

--- a/test/stub_dbus.h
+++ b/test/stub_dbus.h
@@ -22,7 +22,6 @@
    License along with Dsme.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DSME_TEST_STUB_DBUS_H
 #define DSME_TEST_STUB_DBUS_H
 
@@ -34,7 +33,9 @@ GPtrArray *actual_registrations = NULL;
 GPtrArray *dbusmsgq_blocking = NULL;
 GPtrArray *dbusmsgq_async = NULL;
 
-void dbus_connection_flush(DBusConnection *connection __attribute__ ((unused))){}
+void dbus_connection_flush(DBusConnection *connection __attribute__ ((unused)))
+{
+}
 
 dbus_bool_t dbus_connection_send(DBusConnection *connection __attribute__ ((unused)),
                                  DBusMessage    *message,
@@ -53,7 +54,6 @@ void dbus_bus_add_match (DBusConnection *connection __attribute__ ((unused)),
 {
   if (actual_registrations)
         g_ptr_array_add(actual_registrations, g_strdup(rule));
-
 }
 
 static inline void initialize_dbus_stub(void)

--- a/test/stub_dsme_dbus.h
+++ b/test/stub_dsme_dbus.h
@@ -22,7 +22,6 @@
    License along with Dsme.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DSME_TEST_STUB_DSMEDBUS_H
 #define DSME_TEST_STUB_DSMEDBUS_H
 
@@ -63,7 +62,6 @@ void dsme_dbus_unbind_signals(bool* really_bound,
       *really_bound = false;
   }
 }
-
 
 void dsme_dbus_bind_signals(bool*                             bound_already,
                             const dsme_dbus_signal_binding_t* bindings)

--- a/test/stub_timers.h
+++ b/test/stub_timers.h
@@ -25,7 +25,6 @@
    License along with Dsme.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DSME_TEST_STUB_TIMERS_H
 #define DSME_TEST_STUB_TIMERS_H
 

--- a/test/testdriver.h
+++ b/test/testdriver.h
@@ -22,7 +22,6 @@
    License along with Dsme.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DSME_TESTDIVER_H
 #define DSME_TESTDRIVER_H
 

--- a/test/testmod_alarmtracker.c
+++ b/test/testmod_alarmtracker.c
@@ -65,7 +65,6 @@
 #include "stub_dbus.h"
 #include "stub_dsme_dbus.h"
 
-
 /* TIME_STUB */
 #include <time.h>
 #include <dlfcn.h>
@@ -144,7 +143,6 @@ static inline void* queued_dsmesock_(unsigned type, const char* name)
 
 void dsmesock_broadcast(const void* msg)
 {
-
   queued_msg_t*      newmsg;
   dsmemsg_generic_t* genmsg = (dsmemsg_generic_t*)msg;
 
@@ -163,12 +161,10 @@ void dsmesock_broadcast(const void* msg)
       free(newmsg);
       newmsg = NULL;
   }
-
 }
 
 /* TEST DRIVER */
 #include "testdriver.h"
-
 
 #define ALARM_STATE_DIR      "/var/lib/dsme"
 #define ALARM_STATE_FILE     ALARM_STATE_DIR "/alarm_queue_status"
@@ -227,7 +223,6 @@ static void initialize(void)
   initialize_dbus_stub();
   initialize_dsmesock_stub();
   initialize_time_stub();
-
 }
 
 static void finalize(void)
@@ -396,7 +391,6 @@ static void test_init_set_alarm_in5min(void)
       TEST_MSG_INIT(DSM_MSGTYPE_WAKEUP);
   send_message(alarmtracker_module, &wakeupmsg);
 
-
   /* INTERNAL MSGs */
   DSM_MSGTYPE_SET_ALARM_STATE *msg;
   assert(message_queue_is_empty());
@@ -428,8 +422,6 @@ static void test_init_set_alarm_in5min(void)
   unload_alarmtracker();
 }
 
-
-
 /* MAIN */
 
 int main(int argc, char** argv)
@@ -460,7 +452,6 @@ int main(int argc, char** argv)
       }
   }
 
-
   run(test_init_noqueuefile);
   run(test_init_noalarm);
   run(test_init_activealarm);
@@ -474,4 +465,3 @@ int main(int argc, char** argv)
 
   return EXIT_SUCCESS;
 }
-

--- a/test/testmod_emergencycalltracker.c
+++ b/test/testmod_emergencycalltracker.c
@@ -157,7 +157,6 @@ static void test_emergency_call_invalid_state(void)
   unload_emergencycalltracker();
 }
 
-
 /* MAIN */
 
 int main(int argc, char** argv)
@@ -187,7 +186,6 @@ int main(int argc, char** argv)
           return EXIT_SUCCESS;
       }
   }
-
 
   run(test_emergency_call_ongoing);
   run(test_emergency_call_invalid_state);

--- a/test/testmod_state.c
+++ b/test/testmod_state.c
@@ -58,7 +58,6 @@
 #include "stub_timers.h"
 #include "stub_dsme_dbus.h"
 
-
 /* TEST DRIVER */
 #include "testdriver.h"
 
@@ -202,8 +201,6 @@ static void request_shutdown_expecting_shutdown(module_t* state)
 
   expect_shutdown(state);
 }
-
-
 
 /* LIBSTATE TEST CASES */
 
@@ -375,7 +372,6 @@ static void testcase6(void)
   unload_module_under_test(state);
 }
 
-
 static void testcase7(void)
 {
   /* start in actdead */
@@ -423,7 +419,6 @@ static void testcase9(void)
 
   unload_module_under_test(state);
 }
-
 
 static void testcase10(void)
 {
@@ -761,7 +756,6 @@ static void testcase19(void)
   request_shutdown_expecting_actdead(state);
 
   unload_module_under_test(state);
-
 }
 
 static void testcase20(void)
@@ -921,7 +915,6 @@ static void testcase23(void)
   unload_module_under_test(state);
 }
 
-
 /* MAIN */
 
 int main(int argc, char** argv)
@@ -951,7 +944,6 @@ int main(int argc, char** argv)
           return EXIT_SUCCESS;
       }
   }
-
 
   run(testcase1);
   run(testcase2);
@@ -984,4 +976,3 @@ int main(int argc, char** argv)
 
   return EXIT_SUCCESS;
 }
-

--- a/test/testmod_usbtracker.c
+++ b/test/testmod_usbtracker.c
@@ -166,7 +166,6 @@ static void test_send_invalid_usb_status(void)
   unload_usbtracker();
 }
 
-
 /* MAIN */
 
 int main(int argc, char** argv)
@@ -196,7 +195,6 @@ int main(int argc, char** argv)
           return EXIT_SUCCESS;
       }
   }
-
 
   run(test_mounted_to_pc_with_mass_storage);
   run(test_mounted_to_pc_data_in_use);

--- a/test/utils_misc.h
+++ b/test/utils_misc.h
@@ -22,7 +22,6 @@
    License along with Dsme.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DSME_TEST_MISCUTILS_H
 #define DSME_TEST_MISCUTILS_H
 
@@ -98,7 +97,6 @@ static inline void send_message(const module_t* module, const void* msg)
   fprintf(stderr, " SENT]\n");
   handle_message(&endpoint, module, msg);
 }
-
 
 /* UTILITY */
 

--- a/util/Makefile.am
+++ b/util/Makefile.am
@@ -1,10 +1,10 @@
 #
 # Generic options
 #
-AM_CFLAGS = $(C_GENFLAGS) $(C_OPTFLAGS) $(GLIB_CFLAGS)
+AM_CFLAGS = $(C_GENFLAGS) $(C_OPTFLAGS) $(GLIB_CFLAGS) $(DBUS_CFLAGS)
 AM_LDFLAGS = -pthread
 AM_CPPFLAGS = $(CPP_GENFLAGS)
-LDADD = $(GLIB_LIBS) -ldsme -lrt
+LDADD = $(GLIB_LIBS) $(DBUS_LIBS) -ldsme -ldsme_dbus_if -lrt
 
 ACLOCAL_AMFLAGS = -I m4
 

--- a/util/bootstate.c
+++ b/util/bootstate.c
@@ -64,12 +64,12 @@ int main(void)
       FD_ZERO(&rfds);
       FD_SET(dsme_conn->fd, &rfds);
 
-      ret = select(dsme_conn->fd + 1, &rfds, NULL, NULL, &tv); 
+      ret = select(dsme_conn->fd + 1, &rfds, NULL, NULL, &tv);
       if (ret == -1) {
           fprintf(stderr, "error in select()\n");
           printf("MALF");
           return EXIT_FAILURE;
-      } 
+      }
       if (ret == 0) {
           fprintf(stderr, "Timeout!\n");
           printf("MALF");

--- a/util/dsmetool.c
+++ b/util/dsmetool.c
@@ -35,6 +35,7 @@
 
 #include <dsme/state.h>
 #include <dsme/protocol.h>
+#include <dsme/dsme_dbus_if.h>
 
 #include <linux/rtc.h>
 
@@ -50,6 +51,9 @@
 #include <time.h>
 #include <fcntl.h>
 #include <getopt.h>
+#include <errno.h>
+
+#include <dbus/dbus.h>
 
 #define STRINGIFY(x)  STRINGIFY2(x)
 #define STRINGIFY2(x) #x
@@ -277,6 +281,56 @@ static dsmemsg_generic_t *dsmeipc_read(void)
 }
 
 /* ========================================================================= *
+ * DBUSIPC
+ * ========================================================================= */
+
+static DBusConnection *dbusipc_connection(void)
+{
+    static DBusConnection *conn = NULL;
+    if( !conn ) {
+        DBusError err = DBUS_ERROR_INIT;
+        if( !(conn = dbus_bus_get(DBUS_BUS_SYSTEM, &err)) ) {
+            log_error("SystemBus connect failed: %s: %s",
+                      err.name, err.message);
+            exit(EXIT_FAILURE);
+        }
+        dbus_error_free(&err);
+    }
+    return conn;
+}
+
+static void dbusipc_simple_request_bool_arg(const char *method, bool arg)
+{
+    DBusError    err = DBUS_ERROR_INIT;
+    DBusMessage *req = NULL;
+    DBusMessage *rsp = NULL;
+    dbus_bool_t  dta = arg;
+
+    req = dbus_message_new_method_call(dsme_service, dsme_req_path,
+                                       dsme_req_interface, method);
+    if( !req )
+        goto EXIT;
+
+    if( !dbus_message_append_args(req, DBUS_TYPE_BOOLEAN, &dta, DBUS_TYPE_INVALID) )
+        goto EXIT;
+
+    rsp = dbus_connection_send_with_reply_and_block(dbusipc_connection(),
+                                                    req, -1, &err);
+    if( !rsp ) {
+        log_error("%s.%s() failed: %s: %s", dsme_req_interface,
+                  method, err.name, err.message);
+        goto EXIT;
+    }
+
+EXIT:
+    if( rsp )
+        dbus_message_unref(rsp);
+    if( req )
+        dbus_message_unref(req);
+    dbus_error_free(&err);
+}
+
+/* ========================================================================= *
  * DSME_OPTIONS
  * ========================================================================= */
 
@@ -413,6 +467,32 @@ static void xdsme_request_log_defaults(void)
     DSM_MSGTYPE_USE_LOGGING_DEFAULTS req = DSME_MSG_INIT(DSM_MSGTYPE_USE_LOGGING_DEFAULTS);
 
     dsmeipc_send(&req);
+}
+
+static void xdsme_block_shutdown(void)
+{
+    dbusipc_simple_request_bool_arg(dsme_inhibit_shutdown, true);
+}
+
+static void xdsme_allow_shutdown(void)
+{
+    dbusipc_simple_request_bool_arg(dsme_inhibit_shutdown, false);
+}
+
+static void xdsme_block(const char *arg)
+{
+    /* Default to: sleep "forever" / in practice 1 year */
+    struct timespec ts = { .tv_sec  = 365 * 24 * 60 * 60, };
+
+    if( arg ) {
+        int64_t ms = (int64_t)(strtod(arg, NULL) * 1000);
+        if( ms > 0 ) {
+            ts.tv_sec  = (time_t)(ms / 1000);
+            ts.tv_nsec = (long)((ms % 1000) * 1000000);
+        }
+    }
+
+    while( nanosleep(&ts, &ts) == -1 && errno == EINTR ) { }
 }
 
 /* ========================================================================= *
@@ -554,6 +634,13 @@ static void output_usage(const char *name)
 "  -d --start-dbus                 Start DSME's D-Bus services\n"
 "  -s --stop-dbus                  Stop DSME's D-Bus services\n"
 "\n"
+"  -B --block[=<seconds>]          Sleep for specified time / forever\n"
+"                                  Useful for pacing option handling or\n"
+"                                  keeping D-Bus connection alive after\n"
+"                                  other options have been handled.\n"
+"     --block-shutdown             Start shutdown blocking\n"
+"     --allow-shutdown             Stop shutdown blocking\n"
+"\n"
           );
 }
 
@@ -565,23 +652,26 @@ int main(int argc, char *argv[])
 {
     const char *program_name  = argv[0];
     int         retval        = EXIT_FAILURE;
-    const char *short_options = "hdsbvact:l:guoVi:e:L";
+    const char *short_options = "hdsbvact:l:guoVi:e:LB::";
     const struct option long_options[] = {
-        {"help",         no_argument,       NULL, 'h'},
-        {"start-dbus",   no_argument,       NULL, 'd'},
-        {"stop-dbus",    no_argument,       NULL, 's'},
-        {"reboot",       no_argument,       NULL, 'b'},
-        {"version",      no_argument,       NULL, 'v'},
-        {"clear-rtc",    no_argument,       NULL, 'c'},
-        {"get-state",    no_argument,       NULL, 'g'},
-        {"powerup",      no_argument,       NULL, 'u'},
-        {"shutdown",     no_argument,       NULL, 'o'},
-        {"telinit",      required_argument, NULL, 't'},
-        {"loglevel",     required_argument, NULL, 'l'},
-        {"log-include",  required_argument, NULL, 'i'},
-        {"log-exclude",  required_argument, NULL, 'e'},
-        {"log-defaults", no_argument,       NULL, 'L'},
-        {"verbose",      no_argument,       NULL, 'V'},
+        {"help",           no_argument,       NULL, 'h'},
+        {"start-dbus",     no_argument,       NULL, 'd'},
+        {"stop-dbus",      no_argument,       NULL, 's'},
+        {"reboot",         no_argument,       NULL, 'b'},
+        {"version",        no_argument,       NULL, 'v'},
+        {"clear-rtc",      no_argument,       NULL, 'c'},
+        {"get-state",      no_argument,       NULL, 'g'},
+        {"powerup",        no_argument,       NULL, 'u'},
+        {"shutdown",       no_argument,       NULL, 'o'},
+        {"telinit",        required_argument, NULL, 't'},
+        {"loglevel",       required_argument, NULL, 'l'},
+        {"log-include",    required_argument, NULL, 'i'},
+        {"log-exclude",    required_argument, NULL, 'e'},
+        {"log-defaults",   no_argument,       NULL, 'L'},
+        {"verbose",        no_argument,       NULL, 'V'},
+        {"block",          optional_argument, NULL, 'B'},
+        {"block-shutdown", no_argument,       NULL, 900},
+        {"allow-shutdown", no_argument,       NULL, 901},
         {0, 0, 0, 0}
     };
 
@@ -659,6 +749,18 @@ int main(int argc, char *argv[])
         case 'h':
             output_usage(program_name);
             goto DONE;
+
+        case 900:
+            xdsme_block_shutdown();
+            break;
+
+        case 901:
+            xdsme_allow_shutdown();
+            break;
+
+        case 'B':
+            xdsme_block(optarg);
+            break;
 
         case '?':
             fprintf(stderr, "(use --help for instructions)\n");

--- a/util/dsmetool.c
+++ b/util/dsmetool.c
@@ -223,7 +223,6 @@ static void dsmeipc_send_full(const void *msg_, const void *data, size_t size)
         log_error("dsmesock_send: %m");
         exit(EXIT_FAILURE);
     }
-
 }
 
 static void dsmeipc_send(const void *msg)
@@ -518,7 +517,6 @@ static const char *parse_runlevel(char *str)
     };
 
     for( size_t i = 0;  ; ++i ) {
-
         if( lut[i] == 0 ) {
             log_error("%s: not a valid run level", str);
             exit(EXIT_FAILURE);
@@ -679,7 +677,6 @@ DONE:
     retval = EXIT_SUCCESS;
 
 EXIT:
-
     dsmeipc_disconnect();
 
     return retval;

--- a/util/kick_wd.c
+++ b/util/kick_wd.c
@@ -43,8 +43,8 @@ void usage(const char *name)
 	printf("	-h --help			Print usage\n");
 }
 
-int send_kick_wd(void) {
-
+int send_kick_wd(void)
+{
 	int ret = 0;
 	DSM_MSGTYPE_HWWD_KICK msg =
           DSME_MSG_INIT(DSM_MSGTYPE_HWWD_KICK);

--- a/util/kicker.c
+++ b/util/kicker.c
@@ -45,7 +45,6 @@
 
 #define OOM_ADJ_VALUE -17
 
-
 typedef struct wd_t {
     const char* file;   /* pathname of the watchdog device */
     int         period; /* watchdog timeout; 0 for keeping the default */
@@ -59,8 +58,6 @@ static const wd_t wd[] = {
 static int wd_fd[WD_COUNT];
 
 static bool wd_enabled = true;
-
-
 
 static int protect_from_oom(void)
 {
@@ -195,19 +192,17 @@ int main(void)
               FD_SET(dsme_conn->fd, &rfds);
               dsmemsg_generic_t *msg;
 
-              ret = select(dsme_conn->fd + 1, &rfds, NULL, NULL, NULL); 
+              ret = select(dsme_conn->fd + 1, &rfds, NULL, NULL, NULL);
               if (ret == -1) {
                   fprintf(stderr, "error in select()\n");
               } else if (ret == 0) {
                   /* should not happen */
                   fprintf(stderr, "Timeout!\n");
               } else {
-
                   msg = (dsmemsg_generic_t*)dsmesock_receive(dsme_conn);
 
                   if (DSMEMSG_CAST(DSM_MSGTYPE_HWWD_KICK, msg))
                     {
-
                         if (wd_enabled) {
                             int i;
                             for (i = 0; i < WD_COUNT; ++i) {
@@ -222,9 +217,7 @@ int main(void)
                             }
                         }
                     }
-
                     free(msg);
-
                 }
     }
 

--- a/util/waitfordsme.c
+++ b/util/waitfordsme.c
@@ -47,8 +47,8 @@ static bool send_to_dsme(dsmesock_connection_t* conn, const void* msg)
 	return success;
 }
 
-int main(int argc, char* argv[]) {
-	
+int main(int argc, char* argv[])
+{
 	struct timeval start;
 	struct timeval now;
 	dsmesock_connection_t *conn;
@@ -74,9 +74,9 @@ int main(int argc, char* argv[]) {
 				return EXIT_SUCCESS;
 			}
 		}
-		
+
 		gettimeofday(&now, NULL);
-		
+
 		if (now.tv_sec >= (start.tv_sec + DSME_START_TIMEOUT)) {
 			fprintf(stderr,
 				    "%s: ERROR: Timeout waiting for DSME socket\n",


### PR DESCRIPTION
If device is powered off while startup wizard is running, glitching
1st boot actions can cause persistent problems on subsequent bootups.

There is little that can be done about forced hw power offs. But by
having dbus methods available for blocking soft shutdown / reboot
attempts we can at least decrease the likelihood of such problems.

Only privileged processes can block shutdown / reboot.

Blocking does not prevent thermal / battery empty shutdown.
