### PR TITLE
[dbusproxy] Fix inhibit_shutdown method call Introspect data. JB#62856

### DIFF
--- a/modules/dbusproxy.c
+++ b/modules/dbusproxy.c
@@ -265,7 +265,8 @@ static const dsme_dbus_binding_t dbus_methods_array[] =
         .method = block_shutdown,
         .name   = dsme_inhibit_shutdown,
         .priv   = true,
-        .args   = ""
+        .args   =
+            "    <arg direction=\"in\" name=\"inhibit\" type=\"b\"/>\n"
     },
     // sentinel
     {


### PR DESCRIPTION
During review process separate begin and end inhibit methods without arguments were combined into one that takes boolean argument but argument Introspect data was not updated accordingly.

Fix argument Introspect xml snippet to match actual implementation.