### PR TITLE
modules: define PFIX in validatorlistener and upstart

### DIFF
--- a/modules/upstart.c
+++ b/modules/upstart.c
@@ -42,6 +42,8 @@
 #include <sys/utsname.h>
 #include <sys/time.h>
 
+#define PFIX "upstart: "
+
 /* musl-libc compatibility */
 #include <features.h> // for __GLIBC__
 #ifndef __GLIBC__

--- a/modules/validatorlistener.c
+++ b/modules/validatorlistener.c
@@ -48,6 +48,8 @@
 
 #include "../include/dsme/musl-compatibility.h"
 
+#define PFIX "validatorlistener: "
+
 #define DSME_STATIC_STRLEN(s) (sizeof(s) - 1)
 
 // TODO: try to find a header that #defines NETLINK_VALIDATOR


### PR DESCRIPTION
without it, it leads to a bunch of build errors such as:

```
upstart.c:369:42: error: expected ‘)’ before string constant
  369 |                   dsme_log(LOG_ERR, PFIX "/sbin/poweroff failed again");
      |                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
validatorlistener.c:251:41: error: expected ‘)’ before string constant
  251 |                 dsme_log(LOG_INFO, PFIX "OK, not a mandatory file: %s", details);
      |                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```